### PR TITLE
Add server service class and API endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,28 +1,46 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 import os
+
+from server_service import ServerService
 
 app = Flask(__name__)
 CORS(app)
 
+server_service = ServerService()
+
+
 @app.route('/api/status', methods=['GET'])
 def get_status():
-    """
-    Returns the current status of the Minecraft server.
-    This is a placeholder endpoint that can be expanded later.
-    """
-    return jsonify({
-        'status': 'offline',
-        'message': 'Minecraft server manager is ready',
-        'version': '1.0.0'
-    })
+    """Return the current status of the managed server."""
+    status = server_service.status()
+    status.update({"version": "1.0.0"})
+    return jsonify(status)
+
+
+@app.route('/api/start', methods=['POST'])
+def start_server():
+    """Start the managed server process."""
+    command = request.json.get("command") if request.is_json else None
+    if command:
+        server_service.command = command
+    result = server_service.start()
+    return jsonify(result)
+
+
+@app.route('/api/stop', methods=['POST'])
+def stop_server():
+    """Stop the managed server process."""
+    result = server_service.stop()
+    return jsonify(result)
+
 
 @app.route('/api/health', methods=['GET'])
 def health_check():
     """Simple health check endpoint."""
     return jsonify({'healthy': True})
 
+
 if __name__ == '__main__':
-    # Development mode - set FLASK_ENV=production in production environments
     debug_mode = os.environ.get('FLASK_ENV') != 'production'
     app.run(debug=debug_mode, host='0.0.0.0', port=5000)

--- a/server_service.py
+++ b/server_service.py
@@ -1,0 +1,79 @@
+import os
+import subprocess
+import threading
+from typing import List, Optional
+
+
+class ServerService:
+    """Manage the lifecycle of an external server process."""
+
+    def __init__(self, command: Optional[List[str]] = None, cwd: Optional[str] = None):
+        env_command = os.environ.get("SERVER_COMMAND")
+        parsed_env_command: Optional[List[str]] = None
+        if env_command:
+            parsed_env_command = env_command.split()
+
+        self.command = command or parsed_env_command
+        self.cwd = cwd
+        self._process: Optional[subprocess.Popen] = None
+        self._lock = threading.Lock()
+
+    def start(self) -> dict:
+        """Start the server process if it is not already running."""
+        with self._lock:
+            if self.is_running:
+                return {"status": "running", "message": "Server is already running"}
+
+            command_to_run = self.command.split() if isinstance(self.command, str) else self.command
+
+            if not command_to_run:
+                return {
+                    "status": "stopped",
+                    "message": "No server command configured. Set SERVER_COMMAND or pass a command list.",
+                }
+
+            try:
+                self._process = subprocess.Popen(
+                    command_to_run,
+                    cwd=self.cwd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                )
+                return {"status": "running", "message": "Server started", "command": self.command}
+            except Exception as exc:
+                self._process = None
+                return {"status": "stopped", "message": f"Failed to start server: {exc}"}
+
+    def stop(self) -> dict:
+        """Stop the server process if it is running."""
+        with self._lock:
+            if not self.is_running or not self._process:
+                return {"status": "stopped", "message": "Server is not running"}
+
+            try:
+                if self._process.stdin and not self._process.stdin.closed:
+                    try:
+                        self._process.stdin.write("stop\n")
+                        self._process.stdin.flush()
+                    except Exception:
+                        pass
+
+                self._process.terminate()
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+            finally:
+                self._process = None
+
+            return {"status": "stopped", "message": "Server stopped"}
+
+    @property
+    def is_running(self) -> bool:
+        return bool(self._process and self._process.poll() is None)
+
+    def status(self) -> dict:
+        status_value = "running" if self.is_running else "stopped"
+        message = "Server process is running" if self.is_running else "Server process is not running"
+        return {"status": status_value, "message": message}


### PR DESCRIPTION
## Summary
- add a `ServerService` helper to manage starting, stopping, and reporting status for an external server process
- expose `/api/status`, `/api/start`, and `/api/stop` endpoints backed by the new service
- allow server commands to be configured via request payloads or the `SERVER_COMMAND` environment variable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbaec4238832eb797642d49e2a2e8)