### PR TITLE
Improve server start handling and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify
 from flask_cors import CORS
 import os
 
@@ -21,9 +21,6 @@ def get_status():
 @app.route('/api/start', methods=['POST'])
 def start_server():
     """Start the managed server process."""
-    command = request.json.get("command") if request.is_json else None
-    if command:
-        server_service.command = command
     result = server_service.start()
     return jsonify(result)
 

--- a/server/eula.txt
+++ b/server/eula.txt
@@ -1,0 +1,1 @@
+eula=true

--- a/server_service.py
+++ b/server_service.py
@@ -1,22 +1,118 @@
 import os
+import shlex
 import subprocess
 import threading
-from typing import List, Optional
+import time
+from typing import Iterable, List, Optional
 
 
 class ServerService:
     """Manage the lifecycle of an external server process."""
 
-    def __init__(self, command: Optional[List[str]] = None, cwd: Optional[str] = None):
+    DEFAULT_COMMAND = "java -Xmx2G -jar server.jar nogui"
+
+    def __init__(self, command: Optional[Iterable[str]] = None, cwd: Optional[str] = None):
         env_command = os.environ.get("SERVER_COMMAND")
         parsed_env_command: Optional[List[str]] = None
         if env_command:
-            parsed_env_command = env_command.split()
+            parsed_env_command = shlex.split(env_command)
 
-        self.command = command or parsed_env_command
-        self.cwd = cwd
+        self.command = self._parse_command(command or parsed_env_command) or shlex.split(
+            self.DEFAULT_COMMAND
+        )
+        self.cwd = cwd or os.path.join(os.getcwd(), "server")
         self._process: Optional[subprocess.Popen] = None
+        self._stdout_thread: Optional[threading.Thread] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._stdout_buffer: List[str] = []
+        self._stderr_buffer: List[str] = []
         self._lock = threading.Lock()
+
+    def _parse_command(self, command: Optional[Iterable[str]]) -> Optional[List[str]]:
+        if command is None:
+            return None
+        if isinstance(command, str):
+            return shlex.split(command)
+        if isinstance(command, Iterable):
+            return list(command)
+        return None
+
+    def _ensure_server_dir(self) -> None:
+        os.makedirs(self.cwd, exist_ok=True)
+
+    def _ensure_eula(self) -> None:
+        self._ensure_server_dir()
+        eula_path = os.path.join(self.cwd, "eula.txt")
+        if os.path.exists(eula_path):
+            with open(eula_path, "r", encoding="utf-8") as eula_file:
+                contents = eula_file.read()
+            if "eula=true" in contents:
+                return
+        with open(eula_path, "w", encoding="utf-8") as eula_file:
+            eula_file.write("eula=true\n")
+
+    def _check_java_version(self) -> tuple[bool, str]:
+        result = subprocess.run([
+            "java",
+            "-version",
+        ], capture_output=True, text=True)
+        version_output = (result.stdout or "") + (result.stderr or "")
+        if result.returncode != 0:
+            return False, "Java executable not available"
+        if "21" not in version_output:
+            return False, "Java 21 is required to start the server"
+        return True, version_output.strip()
+
+    def _start_log_streams(self) -> None:
+        if not self._process:
+            return
+
+        def _stream(pipe, buffer: List[str]):
+            for line in iter(pipe.readline, ""):
+                buffer.append(line)
+                print(line, end="")
+            pipe.close()
+
+        self._stdout_buffer = []
+        self._stderr_buffer = []
+        self._stdout_thread = threading.Thread(
+            target=_stream, args=(self._process.stdout, self._stdout_buffer), daemon=True
+        )
+        self._stderr_thread = threading.Thread(
+            target=_stream, args=(self._process.stderr, self._stderr_buffer), daemon=True
+        )
+        self._stdout_thread.start()
+        self._stderr_thread.start()
+
+    def _spawn_process(self, command_to_run: List[str]) -> tuple[bool, str]:
+        try:
+            self._process = subprocess.Popen(
+                command_to_run,
+                cwd=self.cwd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self._start_log_streams()
+            time.sleep(0.5)
+
+            if self._process.poll() is not None:
+                exit_code = self._process.returncode
+                stdout_tail = "".join(self._stdout_buffer[-10:])
+                stderr_tail = "".join(self._stderr_buffer[-10:])
+                self._process = None
+                error_message = f"Server process exited immediately (code {exit_code})."
+                if stdout_tail:
+                    error_message += f" stdout: {stdout_tail.strip()}"
+                if stderr_tail:
+                    error_message += f" stderr: {stderr_tail.strip()}"
+                return False, error_message
+
+            return True, "Server started"
+        except Exception as exc:
+            self._process = None
+            return False, f"Failed to start server: {exc}"
 
     def start(self) -> dict:
         """Start the server process if it is not already running."""
@@ -24,7 +120,7 @@ class ServerService:
             if self.is_running:
                 return {"status": "running", "message": "Server is already running"}
 
-            command_to_run = self.command.split() if isinstance(self.command, str) else self.command
+            command_to_run = self.command
 
             if not command_to_run:
                 return {
@@ -32,19 +128,18 @@ class ServerService:
                     "message": "No server command configured. Set SERVER_COMMAND or pass a command list.",
                 }
 
-            try:
-                self._process = subprocess.Popen(
-                    command_to_run,
-                    cwd=self.cwd,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    text=True,
-                )
-                return {"status": "running", "message": "Server started", "command": self.command}
-            except Exception as exc:
-                self._process = None
-                return {"status": "stopped", "message": f"Failed to start server: {exc}"}
+            self._ensure_eula()
+            java_ok, java_message = self._check_java_version()
+            if not java_ok:
+                return {"status": "stopped", "message": java_message}
+
+            started, message = self._spawn_process(command_to_run)
+            status = "running" if started else "stopped"
+            combined_message = message
+            if started:
+                combined_message = f"{message} (Java verified: {java_message})"
+
+            return {"status": status, "message": combined_message, "command": command_to_run}
 
     def stop(self) -> dict:
         """Stop the server process if it is running."""


### PR DESCRIPTION
## Summary
- set a default server start command, enforce Java 21 usage, and ensure the server directory includes an accepted EULA
- switch process handling to use piped stdout/stderr with log streaming and crash detection shortly after launch
- simplify the start endpoint to use configured defaults instead of JSON payload overrides

## Testing
- python -m py_compile app.py server_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6ad2ea20832eb9710c078ccc014f)