### PR TITLE
Add integrated backend, build tooling, and launcher scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ build/
 # Servers
 /servers
 servers.json
+
+# Fabricator build artifacts
+backend/fabricator_backend/frontend_dist/*
+!backend/fabricator_backend/frontend_dist/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+FRONTEND_DIR := frontend
+BACKEND_DIST := backend/fabricator_backend/frontend_dist
+
+.PHONY: build-frontend clean-frontend
+
+build-frontend:
+	cd $(FRONTEND_DIR) && npm install && npm run build
+	rm -rf $(BACKEND_DIST)
+	mkdir -p $(BACKEND_DIST)
+	cp -r $(FRONTEND_DIR)/dist/* $(BACKEND_DIST)/
+
+clean-frontend:
+	rm -rf $(BACKEND_DIST)

--- a/README.md
+++ b/README.md
@@ -1,158 +1,69 @@
 # Fabricator
 
-A minimal Flask + Vue 3 project for managing a personal Minecraft server.
+Fabricator is a desktop-style web application with a Flask backend and a Vue 3 frontend. The backend serves the compiled frontend so users only start one process in production. Windows users can wrap the app with a tray launcher, and Linux users can install it as a systemd service.
 
 ## Project Structure
-
 ```
 Fabricator/
-├── app.py                  # Flask REST API server
-├── requirements.txt        # Python dependencies
-├── .gitignore             # Git ignore rules
-├── frontend/              # Vue 3 frontend application
-│   ├── src/
-│   │   ├── main.js        # Vue app entry point
-│   │   ├── App.vue        # Root component
-│   │   ├── style.css      # Global styles
-│   │   └── components/
-│   │       └── ServerStatus.vue  # Server status component
-│   ├── public/            # Static assets
-│   ├── index.html         # HTML entry point
-│   ├── vite.config.js     # Vite configuration (includes API proxy)
-│   └── package.json       # Node.js dependencies
-└── README.md              # This file
+├── backend/
+│   └── fabricator_backend/
+│       ├── __init__.py            # Flask app factory and SPA serving
+│       ├── __main__.py            # Entrypoint: python -m fabricator_backend
+│       ├── api/                   # Example API routes
+│       └── frontend_dist/         # Built Vue assets copied here
+├── frontend/                      # Vue 3 application (Vite)
+├── tools/
+│   ├── fabricator_launcher.py     # Windows tray launcher
+│   └── install.sh                 # Linux install script (systemd)
+├── Makefile                       # Build helper for frontend assets
+├── requirements.txt               # Python dependencies
+└── README.md
 ```
 
-## Features
+## Development
 
-- **Flask Backend**: Lightweight REST API server with CORS support
-- **Vue 3 Frontend**: Modern Vue 3 with Composition API
-- **Vite Build Tool**: Fast development server with HMR
-- **API Proxy**: Vite dev server proxies `/api/*` requests to Flask backend
-- **Example Endpoint**: `/api/status` returns server status in JSON format
-
-## Development Setup
-
-### Prerequisites
-
-- Python 3.8 or higher
-- Node.js 18 or higher
-- npm or yarn
-
-### Backend Setup
-
-1. Install Python dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-2. Run the Flask development server:
-   ```bash
-   python app.py
-   ```
-
-   The API will be available at `http://localhost:5000`
-
-   **Note:** By default, Flask runs in debug mode for development. To run in production mode, set the environment variable:
-   ```bash
-   FLASK_ENV=production python app.py
-   ```
-   For production deployments, use a production WSGI server like gunicorn.
-
-### Frontend Setup
-
-1. Navigate to the frontend directory:
-   ```bash
-   cd frontend
-   ```
-
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-3. Run the development server:
-   ```bash
-   npm run dev
-   ```
-
-   The frontend will be available at `http://localhost:3000`
-
-### Running Both Servers
-
-You need to run both servers simultaneously in separate terminal windows:
-
-**Terminal 1 (Backend):**
+### Backend
 ```bash
-python app.py
+cd backend
+python -m fabricator_backend
 ```
+The server listens on `http://127.0.0.1:8000` and serves API routes under `/api`.
 
-**Terminal 2 (Frontend):**
+### Frontend
 ```bash
 cd frontend
+npm install
 npm run dev
 ```
-
-Then open your browser to `http://localhost:3000` to see the application.
+The Vite dev server proxies API requests to `http://localhost:8000`.
 
 ## Production Build
+1. Build the frontend and copy assets into the backend package:
+   ```bash
+   make build-frontend
+   ```
+2. Start only the backend (serves both API and SPA):
+   ```bash
+   cd backend
+   python -m fabricator_backend
+   ```
+3. Open `http://127.0.0.1:8000` in your browser.
 
-### Build Frontend
+## Windows Tray Launcher
+- Script: `tools/fabricator_launcher.py`
+- PyInstaller example:
+  ```bash
+  pyinstaller --onefile --noconsole --icon=fabricator_icon.ico tools/fabricator_launcher.py
+  ```
+- The resulting executable starts the backend, opens the UI, shows a tray icon with **Open Fabricator** and **Quit** actions, and shuts down the backend when exiting.
 
+## Linux Install Script (systemd)
+Run the installer as root (or via sudo):
 ```bash
-cd frontend
-npm run build
+bash tools/install.sh
 ```
+The script copies the project into `/opt/fabricator`, creates a virtual environment, installs dependencies, writes `/etc/systemd/system/fabricator.service`, and enables the service so Fabricator runs on boot at `http://127.0.0.1:8000`.
 
-This creates an optimized production build in `frontend/dist/`
-
-### Preview Production Build
-
-```bash
-cd frontend
-npm run preview
-```
-
-## API Endpoints
-
-### `GET /api/status`
-
-Returns the current status of the Minecraft server.
-
-**Response:**
-```json
-{
-  "status": "offline",
-  "message": "Minecraft server manager is ready",
-  "version": "1.0.0"
-}
-```
-
-### `GET /api/health`
-
-Health check endpoint.
-
-**Response:**
-```json
-{
-  "healthy": true
-}
-```
-
-## Expanding the Project
-
-This is a minimal scaffold ready to be expanded. Here are some ideas:
-
-1. **Add server control endpoints**: Start, stop, restart the Minecraft server
-2. **Server properties management**: Edit server.properties file
-3. **Player management**: Whitelist, ban, op players
-4. **Log viewing**: Stream and display server logs
-5. **Backup management**: Create and restore server backups
-6. **Resource monitoring**: CPU, memory, disk usage
-7. **Authentication**: Add user login and session management
-
-## Technologies Used
-
-- **Backend**: Flask 3.0, Flask-CORS
-- **Frontend**: Vue 3, Vite 5
-- **Language**: Python 3, JavaScript (ES6+)
+## Notes
+- The backend serves built frontend files from `backend/fabricator_backend/frontend_dist`. Rebuild and copy assets after frontend changes.
+- Keep dependencies minimal; only Flask/CORS and tray icon requirements are included in `requirements.txt`.

--- a/backend/fabricator_backend/__init__.py
+++ b/backend/fabricator_backend/__init__.py
@@ -1,0 +1,62 @@
+"""Fabricator backend package.
+
+This module exposes the application factory for the Fabricator desktop app.
+"""
+from pathlib import Path
+from flask import Flask, jsonify, send_from_directory
+from flask_cors import CORS
+
+from .api.routes import api_bp
+
+BASE_DIR = Path(__file__).resolve().parent
+FRONTEND_DIST = BASE_DIR / "frontend_dist"
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application.
+
+    The app serves API routes under ``/api`` and the built Vue frontend
+    from ``frontend_dist``. Unknown routes fall back to ``index.html`` to
+    support client-side routing.
+    """
+
+    app = Flask(
+        __name__,
+        static_folder=str(FRONTEND_DIST),
+        static_url_path="",
+    )
+
+    CORS(app)
+    app.register_blueprint(api_bp)
+
+    @app.route("/", defaults={"path": ""})
+    @app.route("/<path:path>")
+    def serve_frontend(path: str):
+        """Serve the compiled frontend or fall back to ``index.html``.
+
+        If the requested asset exists inside ``frontend_dist`` it is served
+        directly; otherwise ``index.html`` is returned for SPA routing. When
+        the frontend has not yet been built, a helpful JSON message is
+        returned.
+        """
+
+        index_file = FRONTEND_DIST / "index.html"
+        requested = FRONTEND_DIST / path
+
+        if path and requested.exists() and requested.is_file():
+            return send_from_directory(FRONTEND_DIST, path)
+
+        if index_file.exists():
+            return send_from_directory(FRONTEND_DIST, "index.html")
+
+        return (
+            jsonify(
+                {
+                    "error": "Frontend not built",
+                    "detail": "Run the build script to generate frontend_dist.",
+                }
+            ),
+            503,
+        )
+
+    return app

--- a/backend/fabricator_backend/__main__.py
+++ b/backend/fabricator_backend/__main__.py
@@ -1,0 +1,11 @@
+"""Entrypoint for running the Fabricator backend with ``python -m``."""
+from . import create_app
+
+
+def main() -> None:
+    app = create_app()
+    app.run(host="127.0.0.1", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/fabricator_backend/api/__init__.py
+++ b/backend/fabricator_backend/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package for Fabricator."""
+
+from .routes import api_bp
+
+__all__ = ["api_bp"]

--- a/backend/fabricator_backend/api/routes.py
+++ b/backend/fabricator_backend/api/routes.py
@@ -1,0 +1,25 @@
+"""Example API routes for the Fabricator backend."""
+from datetime import datetime
+from flask import Blueprint, jsonify
+
+api_bp = Blueprint("api", __name__, url_prefix="/api")
+
+
+@api_bp.get("/status")
+def status():
+    """Return a simple status payload for the UI."""
+
+    return jsonify(
+        {
+            "status": "ok",
+            "message": "Fabricator backend is running",
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+        }
+    )
+
+
+@api_bp.get("/health")
+def health():
+    """Health check endpoint."""
+
+    return jsonify({"healthy": True})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "minecraft-server-manager-frontend",
+  "name": "fabricator-frontend",
   "version": "1.0.0",
   "type": "module",
   "scripts": {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://localhost:8000',
         changeOrigin: true
       }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.0
 Flask-CORS==4.0.0
 requests==2.31.0
 psutil==5.9.8
+pystray==0.19.5
+Pillow==10.3.0

--- a/tools/fabricator_launcher.py
+++ b/tools/fabricator_launcher.py
@@ -1,0 +1,150 @@
+"""Windows system tray launcher for Fabricator.
+
+Build example (PyInstaller):
+    pyinstaller --onefile --noconsole --icon=fabricator_icon.ico tools/fabricator_launcher.py
+"""
+from __future__ import annotations
+
+import atexit
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+from typing import Optional
+
+import pystray
+from PIL import Image, ImageDraw
+
+BACKEND_URL = "http://127.0.0.1:8000"
+BACKEND_MODULE = "fabricator_backend"
+BACKEND_PROCESS: Optional[subprocess.Popen] = None
+
+
+def _resource_path() -> Path:
+    """Resolve the directory containing bundled resources."""
+
+    return Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
+
+
+def _project_root() -> Path:
+    """Get the project root in source or bundled layouts."""
+
+    base = _resource_path()
+    return base.parent if base.name == "tools" else base
+
+
+def _backend_workdir() -> Path:
+    """Directory from which the backend module should be started."""
+
+    return _project_root() / "backend"
+
+
+def _find_icon() -> Optional[Path]:
+    """Look for an icon bundled alongside the launcher."""
+
+    base = _resource_path()
+    for name in ("fabricator_icon.png", "fabricator_icon.ico"):
+        candidate = base / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_icon_image() -> Image.Image:
+    """Load the tray icon image, falling back to a simple placeholder."""
+
+    icon_path = _find_icon()
+    if icon_path:
+        return Image.open(icon_path)
+
+    image = Image.new("RGBA", (64, 64), (50, 50, 50, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((8, 8, 56, 56), outline=(200, 200, 200, 255), width=4)
+    draw.line((8, 8, 56, 56), fill=(120, 180, 255, 255), width=4)
+    draw.line((8, 56, 56, 8), fill=(120, 180, 255, 255), width=4)
+    return image
+
+
+def _python_command() -> str:
+    """Locate the Python executable used to run the backend."""
+
+    if getattr(sys, 'frozen', False):
+        bundled_python = Path(sys.executable).with_name('python.exe')
+        if bundled_python.exists():
+            return str(bundled_python)
+    return sys.executable
+
+
+def start_backend() -> None:
+    """Start the Flask backend as a subprocess."""
+
+    global BACKEND_PROCESS
+    if BACKEND_PROCESS and BACKEND_PROCESS.poll() is None:
+        return
+
+    command = [_python_command(), "-m", BACKEND_MODULE]
+    BACKEND_PROCESS = subprocess.Popen(
+        command,
+        cwd=str(_backend_workdir()),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def stop_backend() -> None:
+    """Terminate the backend subprocess cleanly."""
+
+    global BACKEND_PROCESS
+    if not BACKEND_PROCESS:
+        return
+
+    if BACKEND_PROCESS.poll() is None:
+        BACKEND_PROCESS.terminate()
+        try:
+            BACKEND_PROCESS.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            BACKEND_PROCESS.kill()
+    BACKEND_PROCESS = None
+
+
+@atexit.register
+def _cleanup_process() -> None:
+    stop_backend()
+
+
+def open_ui() -> None:
+    """Open the Fabricator UI in the default browser."""
+
+    webbrowser.open(BACKEND_URL)
+
+
+def _on_open(icon: pystray.Icon, item: pystray.MenuItem) -> None:  # type: ignore[unused-argument]
+    open_ui()
+
+
+def _on_quit(icon: pystray.Icon, item: pystray.MenuItem) -> None:  # type: ignore[unused-argument]
+    icon.stop()
+    stop_backend()
+
+
+def _menu() -> pystray.Menu:
+    return pystray.Menu(
+        pystray.MenuItem("Open Fabricator", _on_open),
+        pystray.MenuItem("Quit", _on_quit),
+    )
+
+
+def main() -> None:
+    """Start the backend, open the UI, and show the tray icon."""
+
+    start_backend()
+    time.sleep(1)
+    open_ui()
+
+    tray_icon = pystray.Icon("Fabricator", _load_icon_image(), "Fabricator", menu=_menu())
+    tray_icon.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="/opt/fabricator"
+SERVICE_FILE="/etc/systemd/system/fabricator.service"
+SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This installer must be run as root (try: sudo bash tools/install.sh)."
+  exit 1
+fi
+
+echo "Installing Fabricator to ${APP_DIR}"
+rm -rf "${APP_DIR}"
+mkdir -p "${APP_DIR}"
+
+# Copy project files
+cp -r "${PROJECT_ROOT}"/. "${APP_DIR}"/
+
+# Create virtual environment and install dependencies
+python3 -m venv "${APP_DIR}/venv"
+"${APP_DIR}/venv/bin/pip" install --upgrade pip
+"${APP_DIR}/venv/bin/pip" install -r "${APP_DIR}/requirements.txt"
+
+# Write systemd service
+cat > "${SERVICE_FILE}" <<EOF
+[Unit]
+Description=Fabricator Server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${APP_DIR}/backend
+ExecStart=${APP_DIR}/venv/bin/python -m fabricator_backend
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now fabricator.service
+
+echo "Fabricator is running at http://127.0.0.1:8000"


### PR DESCRIPTION
## Summary
- implement a Flask-based fabricator_backend package that serves both API routes and the built Vue SPA
- add build helpers, Windows tray launcher, and Linux systemd installer to run the app from a single entrypoint
- update frontend configuration and documentation to match the new unified workflow

## Testing
- python -m py_compile backend/fabricator_backend/__init__.py backend/fabricator_backend/__main__.py backend/fabricator_backend/api/routes.py tools/fabricator_launcher.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692efe2ef05c832e8c921d22ea587f97)