### PR TITLE
fix(docker): bump psutil 5.9.8 -> 7.0.0 for linux/arm64 wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
 pillow==12.1.1
-psutil==5.9.8
+psutil==7.0.0
 pyinstaller==6.20.0
 pystray==0.19.5
 python-dotenv==1.2.2


### PR DESCRIPTION
psutil 5.9.8 ships no linux aarch64 wheel, so the arm64 image build fell back to compiling its C extension from sdist — which python:3.11-slim can't do (no compiler), failing `pip install` on the arm64 leg. psutil >=6.0.0 publishes aarch64 manylinux wheels; 7.0.0 keeps the app's usage (Process, Error, cpu_percent, virtual_memory) unchanged. Verified: installs wheel-only on arm64+amd64, and all four app call sites work on 7.0.0.