### PR TITLE
Whole bunch of nothing(Bug fixes)

### DIFF
--- a/backend/backups/restore.py
+++ b/backend/backups/restore.py
@@ -258,13 +258,6 @@ def run_restore(
                 "mode": mode,
             },
         )
-        progress.update(
-            job_id,
-            phase="done",
-            restore_record_id=restore_record["id"],
-            safety_snapshot_id=safety["id"],
-            duration_seconds=duration,
-        )
     except Exception as exc:
         if progress.get(job_id).get("phase") not in ("done", "failed"):
             progress.update(job_id, phase="failed", error=str(exc))
@@ -275,6 +268,19 @@ def run_restore(
         if was_running:
             progress.update(job_id, phase="restarting")
             _restart_server_safe(server, registry, job_id)
+        # Assert the terminal phase AFTER any restart. Previously "done" was set
+        # before the restart, then clobbered by "restarting", which was never
+        # reset — leaving the job stuck non-terminal: progress.is_active() stays
+        # True and the frontend poll loop never finishes even though the restore
+        # succeeded. _restart_server_safe only records restart_error on failure,
+        # so "done" is the correct terminal state either way.
+        progress.update(
+            job_id,
+            phase="done",
+            restore_record_id=restore_record["id"],
+            safety_snapshot_id=safety["id"],
+            duration_seconds=duration,
+        )
         return restore_record
     finally:
         server_lock.release()
@@ -306,19 +312,32 @@ def _write_safety_snapshot(
         )
 
     tmp_path = storage_path / (final_path.name + ".partial")
+
+    # Exclude the storage dir wherever it sits inside the install tree — it may
+    # be NESTED (e.g. <install>/data/backups), not just a direct child — so we
+    # never recursively pack prior backups into the safety tar (which would grow
+    # it with every restore). A tarfile filter on the arcname drops only the
+    # storage subtree while keeping unrelated siblings under the same
+    # intermediate dir (e.g. <install>/data/other).
+    try:
+        storage_rel = (
+            storage_path.resolve().relative_to(install_path.resolve()).as_posix()
+        )
+    except (ValueError, OSError):
+        storage_rel = None  # storage lives outside the install tree — nothing to skip
+
+    def _drop_storage(tarinfo):
+        if storage_rel and (
+            tarinfo.name == storage_rel
+            or tarinfo.name.startswith(storage_rel + "/")
+        ):
+            return None
+        return tarinfo
+
     try:
         with tarfile.open(tmp_path, "w") as tf:
             for entry in sorted(install_path.iterdir()):
-                # Skip the storage dir if it lives inside the install
-                # tree — recursively packing the backups folder into the
-                # safety would grow with every restore.
-                try:
-                    entry_resolved = entry.resolve()
-                    if storage_path.resolve() == entry_resolved:
-                        continue
-                except OSError:
-                    pass
-                tf.add(entry, arcname=entry.name)
+                tf.add(entry, arcname=entry.name, filter=_drop_storage)
         os.replace(tmp_path, final_path)
     except Exception:
         try:

--- a/backend/backups/routes.py
+++ b/backend/backups/routes.py
@@ -452,11 +452,15 @@ def _purge_archive_files(
     ``storagePath`` are unlinked — defensive against two configs that
     happen to point at overlapping storage dirs.
     """
-    storage_path_raw = (cfg.get("storagePath") or "").strip()
-    storage_path = (
-        Path(storage_path_raw).expanduser().resolve()
-        if storage_path_raw else None
-    )
+    # Resolve the config's EFFECTIVE storage dir exactly like the backup writer
+    # does (storage.resolve_config_storage_path), so purge also matches files
+    # under the default <install>/backups location. An empty storagePath is a
+    # supported default; reading the raw value here made purge a silent no-op
+    # for such configs, orphaning every archive on disk.
+    try:
+        storage_path = storage.resolve_config_storage_path(cfg).resolve()
+    except (ValueError, OSError):
+        storage_path = None
 
     deleted: List[str] = []
     retained: List[str] = []

--- a/backend/backups/scheduler.py
+++ b/backend/backups/scheduler.py
@@ -217,9 +217,20 @@ def _build_trigger(schedule: Dict[str, Any]):
     if frequency_hours == 24:
         return CronTrigger(hour=time_of_day.hour, minute=time_of_day.minute)
 
-    # IntervalTrigger anchored at the next occurrence of ``timeOfDay``
-    # so "every 6h at :30" still feels predictable from the user's PoV.
-    now = datetime.now(timezone.utc)
+    # IntervalTrigger anchored at the next occurrence of ``timeOfDay`` so
+    # "every 6h at :30" stays predictable. Anchor in LOCAL time — the same frame
+    # CronTrigger(hour=, minute=) uses for daily schedules — so a sub-daily and a
+    # daily schedule with the same timeOfDay fire at the same wall-clock time
+    # instead of drifting by the host's UTC offset.
+    anchor = _interval_anchor(time_of_day, frequency_hours, datetime.now())
+    return IntervalTrigger(hours=frequency_hours, start_date=anchor)
+
+
+def _interval_anchor(
+    time_of_day: dtime, frequency_hours: int, now: datetime
+) -> datetime:
+    """Next occurrence of ``time_of_day`` at or after ``now`` (in ``now``'s tz),
+    rolled forward by whole ``frequency_hours`` when today's slot has passed."""
     anchor = now.replace(
         hour=time_of_day.hour,
         minute=time_of_day.minute,
@@ -228,7 +239,7 @@ def _build_trigger(schedule: Dict[str, Any]):
     )
     if anchor <= now:
         anchor = anchor + timedelta(hours=frequency_hours)
-    return IntervalTrigger(hours=frequency_hours, start_date=anchor)
+    return anchor
 
 
 def _run_scheduled_backup(config_id: str) -> None:

--- a/backend/backups/world_import.py
+++ b/backend/backups/world_import.py
@@ -286,6 +286,18 @@ def run_world_import(
         progress.update(job_id, phase="swapping")
         _swap_world_dirs(install_path, normalized_root, produced, server_id)
 
+        # Replace semantics: drop any live dimension dir for this level that the
+        # imported world did NOT provide — otherwise a world with fewer
+        # dimensions inherits the previous world's Nether/End and yields a
+        # mismatched world. The mandatory safety snapshot above already captured
+        # them, so this is recoverable.
+        for suffix in ("_nether", "_the_end"):
+            dim_name = f"{level_name}{suffix}"
+            if dim_name not in produced:
+                stale_dim = install_path / dim_name
+                if stale_dim.is_dir():
+                    shutil.rmtree(stale_dim, ignore_errors=True)
+
         duration = round(time.monotonic() - start_time, 3)
         import_record = storage.record_snapshot(
             server_id,
@@ -305,15 +317,6 @@ def run_world_import(
                 "mode": "import",
             },
         )
-        progress.update(
-            job_id,
-            phase="done",
-            import_record_id=import_record["id"],
-            safety_snapshot_id=safety["id"],
-            layout=detection["layout"],
-            world_dirs=produced,
-            duration_seconds=duration,
-        )
     except Exception as exc:
         if progress.get(job_id).get("phase") not in ("done", "failed"):
             progress.update(job_id, phase="failed", error=str(exc))
@@ -324,6 +327,19 @@ def run_world_import(
         if was_running:
             progress.update(job_id, phase="restarting")
             _restart_server_safe(server, registry, job_id)
+        # Assert the terminal phase AFTER any restart (mirror of run_restore):
+        # otherwise "restarting" clobbers "done" and is never reset, so
+        # progress.is_active() stays True and the frontend poll loop never ends
+        # even though the import succeeded.
+        progress.update(
+            job_id,
+            phase="done",
+            import_record_id=import_record["id"],
+            safety_snapshot_id=safety["id"],
+            layout=detection["layout"],
+            world_dirs=produced,
+            duration_seconds=duration,
+        )
         return import_record
     finally:
         if staging_root is not None and staging_root.exists():
@@ -577,16 +593,30 @@ def _write_safety_snapshot(
         )
 
     tmp_path = storage_path / (final_path.name + ".partial")
+
+    # Exclude the storage dir wherever it sits inside the install tree (mirror of
+    # restore._write_safety_snapshot). Here storage_path is <install>/backups (a
+    # direct child), but a tarfile arcname filter keeps the two copies identical
+    # and correct even if that ever nests — no recursive self-inclusion.
+    try:
+        storage_rel = (
+            storage_path.resolve().relative_to(install_path.resolve()).as_posix()
+        )
+    except (ValueError, OSError):
+        storage_rel = None
+
+    def _drop_storage(tarinfo):
+        if storage_rel and (
+            tarinfo.name == storage_rel
+            or tarinfo.name.startswith(storage_rel + "/")
+        ):
+            return None
+        return tarinfo
+
     try:
         with tarfile.open(tmp_path, "w") as tf:
             for entry in sorted(install_path.iterdir()):
-                # Don't pack the safety storage dir into itself.
-                try:
-                    if storage_path.resolve() == entry.resolve():
-                        continue
-                except OSError:
-                    pass
-                tf.add(entry, arcname=entry.name)
+                tf.add(entry, arcname=entry.name, filter=_drop_storage)
         os.replace(tmp_path, final_path)
     except Exception:
         tmp_path.unlink(missing_ok=True)

--- a/backend/backups/world_import.py
+++ b/backend/backups/world_import.py
@@ -133,7 +133,11 @@ def validate_upload_archive(path: Path) -> str:
     to run inline before spawning the worker.
     """
     kind, names = _list_archive_names(path)
-    if not _find_level_dat_root(names):
+    # _find_level_dat_root returns None only when NO level.dat exists; a world
+    # sitting at the archive root yields "" (empty string). `not ""` is True, so
+    # a truthiness check would wrongly reject the common "zip the world folder's
+    # contents" layout. Distinguish absent (None) from root-level ("").
+    if _find_level_dat_root(names) is None:
         raise InvalidWorldArchiveError(
             "Archive does not contain a level.dat — it is not a Minecraft world"
         )

--- a/backend/playit/agent.py
+++ b/backend/playit/agent.py
@@ -205,9 +205,18 @@ def start() -> None:
     # start (missing binary) remembers the user's intent to re-enable.
     set_enabled(True)
 
-    # Orphan reap BEFORE bumping gen so we don't race with our own watchdog
-    # of an old run. Safe to call even when no PID file exists.
-    _reap_orphan_daemon()
+    # Only reap a leftover orphan from a PREVIOUS run — NEVER our own healthy
+    # daemon. While a daemon we own is alive, _write_pid_file has left the PID
+    # file pointing at it, and _reap_orphan_daemon (which only checks the PID
+    # file + _is_pid_alive, not _proc) can't tell it apart, so an unconditional
+    # reap here would SIGTERM/SIGKILL our own live tunnel on a redundant start()
+    # and defeat the "already running" fast-return below.
+    with _lock:
+        own_live_daemon = _proc is not None and _proc.poll() is None
+    if not own_live_daemon:
+        # Reap BEFORE bumping gen so we don't race with our own watchdog of an
+        # old run. Safe to call even when no PID file exists.
+        _reap_orphan_daemon()
 
     with _lock:
         if _proc is not None and _proc.poll() is None:

--- a/backend/playit/agent.py
+++ b/backend/playit/agent.py
@@ -589,7 +589,7 @@ def _run_daemon(my_gen: int, daemon_bin: str, secret: Path) -> None:
     daemon writes to stdout (merged with stderr by Popen), feeding the reader
     a single coherent stream we can both parse for events and tail for errors.
     """
-    global _proc, _status, _error_reason
+    global _proc, _status, _error_reason, _gen
 
     socket = playit_binary.socket_path()
 
@@ -650,6 +650,20 @@ def _run_daemon(my_gen: int, daemon_bin: str, secret: Path) -> None:
     # Reader exited (proc closed stdout). Clear the PID file so the next
     # start() doesn't try to reap a no-longer-relevant process.
     _clear_pid_file()
+
+    # The daemon exited on its own (crash / OOM / external kill / clean exit)
+    # rather than via stop()/restart — otherwise a newer generation would have
+    # already advanced _gen. _read_daemon_stdout has recorded the terminal
+    # status ("stopped" or "error"); retire THIS generation so its rundata
+    # poller stops instead of hammering the API forever and resurrecting the
+    # dead daemon to "running" off stale server-side tunnel state. This is the
+    # fast/common path (fires the instant the reader sees stdout EOF); the
+    # poller's own liveness check is the fallback for the rare case where a
+    # child holds the stdout pipe open and the reader never returns here. Only
+    # bump if we're still current.
+    with _lock:
+        if my_gen == _gen:
+            _gen += 1
 
 
 def _read_daemon_stdout(proc: subprocess.Popen, my_gen: int) -> None:
@@ -762,7 +776,7 @@ def _start_rundata_poller(my_gen: int) -> None:
 def _rundata_poller(my_gen: int) -> None:
     """Long-running poller — owns the daemon-level running/error transitions
     and populates _tunnels. Gen-token disciplined."""
-    global _status, _error_reason
+    global _status, _error_reason, _gen
 
     # Give the daemon a moment to authenticate with the playit API before the
     # first call, otherwise we'd just get a 401 for the first cycle.
@@ -779,6 +793,29 @@ def _rundata_poller(my_gen: int) -> None:
 
         with _lock:
             if my_gen != _gen:
+                return
+            # Daemon-death fallback. _read_daemon_stdout + the _gen bump in
+            # _run_daemon are the PRIMARY retirement path (they also derive a
+            # rich error_reason from the log tail), but they only fire on stdout
+            # EOF — if the daemon exits while a child it spawned keeps the shared
+            # stdout pipe open, the reader blocks forever and never retires this
+            # generation. Detect the dead process here so we (a) stop polling
+            # instead of hammering the API forever, and (b) never fall through to
+            # the branches below and label a corpse "running" off stale
+            # server-side rundata. Runs BEFORE the body branches for exactly (b).
+            daemon_rc = _proc.poll() if _proc is not None else None
+            if daemon_rc is not None:
+                # Classify by exit code exactly like _read_daemon_stdout does, so
+                # a clean self-exit (rc 0) reports "stopped", not a spurious
+                # "error". Preserve any richer error_reason the reader already
+                # recorded before we won the lock.
+                if _status not in ("error", "stopped"):
+                    if daemon_rc == 0:
+                        _status = "stopped"
+                    else:
+                        _status = "error"
+                        _error_reason = _error_reason or f"playitd exited with code {daemon_rc}"
+                _gen += 1                    # retire this generation
                 return
             if body is _RUNDATA_UNAUTHORIZED:
                 # The API rejected our agent key. One 401 can be a blip right
@@ -896,6 +933,17 @@ def _apply_rundata_to_state(body: dict) -> None:
     # already surfaced — that signal is faster and more specific. Leave the
     # tunnel list alone too; the UI shows the agent-level error regardless.
     if _status == "error" and _error_reason and _is_inline_failure(_error_reason):
+        return
+
+    # Never resurrect a daemon that has already exited. If the process we own is
+    # gone (crashed / externally killed / clean exit), its terminal status was
+    # already recorded; playit.gg's rundata still reports the agent's server-side
+    # tunnels for a while after a local exit, and flipping back to "running" off
+    # that stale data would mask a dead tunnel. Defensive self-guard: the only
+    # caller (_rundata_poller) already performs the same liveness check under the
+    # same lock before calling us, so in practice _proc is live here — this keeps
+    # the function correct in isolation rather than relying on that invariant.
+    if _proc is None or _proc.poll() is not None:
         return
 
     data = (body or {}).get("data") or {}

--- a/backend/server/java_manager.py
+++ b/backend/server/java_manager.py
@@ -574,6 +574,23 @@ def install_java(major: int, archive_path: Path) -> str:
 _install_tasks_lock = threading.Lock()
 _install_tasks: dict[str, dict] = {}
 
+# One lock per effective-major serialises the download+extract+install of that
+# major: two concurrent workers share the fixed download path and the managed
+# target dir and would corrupt each other. Unlike deduping to a single task,
+# this keeps each request an independently cancellable task with its own
+# cancel_event and its own (requested_major, substituted) metadata.
+_major_install_locks: dict[int, threading.Lock] = {}
+_major_install_locks_guard = threading.Lock()
+
+
+def _major_install_lock(major: int) -> threading.Lock:
+    with _major_install_locks_guard:
+        lock = _major_install_locks.get(major)
+        if lock is None:
+            lock = threading.Lock()
+            _major_install_locks[major] = lock
+        return lock
+
 # Internal handles per task — kept out of ``_install_tasks`` so the dict that
 # escapes via :func:`get_install_task` stays JSON-serialisable. Keys mirror
 # ``_install_tasks``; entries are removed by :func:`_evict_old_install_tasks`.
@@ -700,15 +717,26 @@ def _run_install_task(
 
     try:
         _check_cancel_or_timeout()
-        _update_task(task_id, status="downloading", downloaded=0, total=0)
-        archive = download_java(
-            install_major,
-            progress_callback=on_progress,
-            cancel_event=cancel_event,
-        )
-        _check_cancel_or_timeout()
-        _update_task(task_id, status="installing")
-        java_path = install_java(install_major, archive)
+        # Serialize with any other in-flight install of the SAME major — they
+        # share the fixed download path and the managed target dir. Poll-acquire
+        # in short slices so cancel and the wall-clock cap stay responsive while
+        # we wait for a concurrent install to finish.
+        major_lock = _major_install_lock(install_major)
+        while not major_lock.acquire(timeout=0.5):
+            _check_cancel_or_timeout()
+        try:
+            _check_cancel_or_timeout()
+            _update_task(task_id, status="downloading", downloaded=0, total=0)
+            archive = download_java(
+                install_major,
+                progress_callback=on_progress,
+                cancel_event=cancel_event,
+            )
+            _check_cancel_or_timeout()
+            _update_task(task_id, status="installing")
+            java_path = install_java(install_major, archive)
+        finally:
+            major_lock.release()
         # Atomic cancel-vs-success finalisation under the lock. Without it, a
         # concurrent ``cancel_install_task`` could interleave between the
         # is_set() check and the ``status="done"`` write — either direction

--- a/backend/server/manager.py
+++ b/backend/server/manager.py
@@ -9,6 +9,7 @@ from typing import Iterable, List, Optional
 
 from backend.utils import platform as platform_utils
 from backend.utils.java import parse_java_major
+from backend.utils.time import iso_z_now
 try:
     import psutil  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency fallback
@@ -58,8 +59,14 @@ class ServerManager:
         self._ps_process: Optional["psutil.Process"] = None  # type: ignore[name-defined]
         self._stdout_thread: Optional[threading.Thread] = None
         self._stderr_thread: Optional[threading.Thread] = None
-        self._stdout_buffer: List[str] = []
-        self._stderr_buffer: List[str] = []
+        # Each entry is ``(capture_ts, text)`` where capture_ts is an ISO-Z
+        # timestamp taken when Fabricator read the line. The server's own
+        # ``[HH:MM:SS]`` is in the JVM's timezone (UTC on most hosts); shipping
+        # an absolute capture time instead lets the frontend render it in the
+        # viewer's local timezone. Storing the pair as one tuple keeps the
+        # lock-free append in ``_stream`` a single atomic list op.
+        self._stdout_buffer: List[tuple[str, str]] = []
+        self._stderr_buffer: List[tuple[str, str]] = []
         self._players: Dict[str, OnlinePlayer] = {}
         self._lock = threading.Lock()
 
@@ -189,9 +196,9 @@ class ServerManager:
         if not self._process:
             return
 
-        def _stream(pipe, buffer: List[str]):
+        def _stream(pipe, buffer: List[tuple[str, str]]):
             for line in iter(pipe.readline, ""):
-                buffer.append(line)
+                buffer.append((iso_z_now(), line))
                 if len(buffer) > self.MAX_LOG_LINES:
                     del buffer[: len(buffer) - self.MAX_LOG_LINES]
                 join_match = self._PLAYER_JOIN_RE.search(line)
@@ -238,8 +245,8 @@ class ServerManager:
 
             if self._process.poll() is not None:
                 exit_code = self._process.returncode
-                stdout_tail = "".join(self._stdout_buffer[-10:])
-                stderr_tail = "".join(self._stderr_buffer[-10:])
+                stdout_tail = "".join(text for _, text in self._stdout_buffer[-10:])
+                stderr_tail = "".join(text for _, text in self._stderr_buffer[-10:])
                 self._process = None
                 error_message = f"Server process exited immediately (code {exit_code})."
                 if stdout_tail:
@@ -393,8 +400,8 @@ class ServerManager:
             stderr = self._stderr_buffer[-limit:]
             running = self.is_running
         return {
-            "stdout": stdout,
-            "stderr": stderr,
+            "stdout": [{"ts": ts, "text": text} for ts, text in stdout],
+            "stderr": [{"ts": ts, "text": text} for ts, text in stderr],
             "running": running
         }
 
@@ -429,7 +436,7 @@ class ServerManager:
                 # thread can't truncate-then-resize the buffer mid-iter.
                 pending = self._stdout_buffer[start_index:]
                 start_index = len(self._stdout_buffer)
-            for line in pending:
+            for _, line in pending:
                 if pattern.search(line):
                     return True
             time.sleep(poll_interval)
@@ -438,7 +445,7 @@ class ServerManager:
         # arrives after the last poll-sleep but before timeout.
         with self._lock:
             pending = self._stdout_buffer[start_index:]
-        for line in pending:
+        for _, line in pending:
             if pattern.search(line):
                 return True
         return False

--- a/backend/server/manager.py
+++ b/backend/server/manager.py
@@ -140,6 +140,29 @@ class ServerManager:
             return self.command[0]
         return "java"
 
+    # JDK 23 (JEP 471) deprecated sun.misc.Unsafe's memory-access methods; JDK 24
+    # (JEP 498) makes the JVM print a WARNING the first time one is called.
+    # Minecraft's JOML math library calls them, so every modern server spams four
+    # scary-looking lines on boot. This flag opts back into silent access.
+    _UNSAFE_ACCESS_FLAG = "--sun-misc-unsafe-memory-access=allow"
+
+    def _with_unsafe_suppression(self, command: List[str], java_major: int) -> List[str]:
+        """Insert the Unsafe-warning suppression flag for Java 23+ launches.
+
+        The flag only exists on Java 23 and newer; passing it to an older JVM
+        aborts startup, so it is gated on the probed major version. A JVM option
+        must precede ``-jar``/the main class, so it goes right after the java
+        executable. Skipped if the user already set it themselves.
+        """
+        if java_major < 23 or not command:
+            return command
+        if any(
+            isinstance(arg, str) and arg.startswith("--sun-misc-unsafe-memory-access")
+            for arg in command
+        ):
+            return command
+        return [command[0], self._UNSAFE_ACCESS_FLAG, *command[1:]]
+
     def probe_java(self) -> dict:
         java_exec = self._java_executable()
         try:
@@ -300,6 +323,7 @@ class ServerManager:
                     "server_java_target": java_info.get("java_exec"),
                 }
 
+            command_to_run = self._with_unsafe_suppression(command_to_run, detected_java)
             started, message = self._spawn_process(command_to_run)
             status = "running" if started else "stopped"
             combined_message = message

--- a/backend/server/manager.py
+++ b/backend/server/manager.py
@@ -41,8 +41,26 @@ class ServerManager:
 
     DEFAULT_COMMAND = "java -Xmx2G -jar server.jar nogui"
     MAX_LOG_LINES = 10_000
-    _PLAYER_JOIN_RE = re.compile(r'\[.*?INFO\]: (.+) joined the game')
-    _PLAYER_LEAVE_RE = re.compile(r'\[.*?INFO\]: (.+) left the game')
+    # Player join/leave detection from server stdout. The log prefix is pinned
+    # to the START of the line — "[<timestamp>] [<thread>/INFO]" (plus Forge's
+    # optional "[<category>]") — so a player who types "INFO]: Ghost joined the
+    # game" (or "[x/INFO]: ...") into CHAT can't make the prefix re-anchor onto
+    # that embedded marker and spoof a join/leave. The name is then restricted
+    # to characters a real username can't share with the chat wrapper ("<", ">")
+    # or the 1.19+ "[Not Secure]" prefix ("[", "]"), which rejects "<Notch> ..."
+    # and "[Not Secure] <Notch> ..." while still allowing spaces (Bedrock/Geyser
+    # gamertags). Lines are ANSI-stripped (see _ANSI_RE) before matching, so a
+    # colour-wrapped name isn't dropped by the "[" exclusion.
+    _LOG_PREFIX = (
+        r'^(?:'
+        r'\[[^\]]*INFO\]'                            # legacy single bracket: [HH:MM:SS INFO]
+        r'|\[[^\]]+\] \[[^\]]*INFO\](?: \[[^\]]*\])?'  # [time] [thread/INFO] (+ Forge [category])
+        r'): '
+    )
+    _PLAYER_JOIN_RE = re.compile(_LOG_PREFIX + r'([^<>\[\]]+) joined the game')
+    _PLAYER_LEAVE_RE = re.compile(_LOG_PREFIX + r'([^<>\[\]]+) left the game')
+    # SGR colour escapes some setups emit around the message on the pipe.
+    _ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')
 
     def __init__(self, cwd: str, command: Optional[Iterable[str]] = None):
         env_command = os.environ.get("SERVER_COMMAND")
@@ -63,12 +81,30 @@ class ServerManager:
         # timestamp taken when Fabricator read the line. The server's own
         # ``[HH:MM:SS]`` is in the JVM's timezone (UTC on most hosts); shipping
         # an absolute capture time instead lets the frontend render it in the
-        # viewer's local timezone. Storing the pair as one tuple keeps the
-        # lock-free append in ``_stream`` a single atomic list op.
+        # viewer's local timezone. Appends/reads are guarded by ``_buffer_lock``
+        # (below).
         self._stdout_buffer: List[tuple[str, str]] = []
         self._stderr_buffer: List[tuple[str, str]] = []
+        # Monotonic count of stdout lines ever appended — never reset by the
+        # MAX_LOG_LINES front-truncation. wait_for_log() diffs this instead of
+        # absolute buffer indices, which stop advancing once the buffer
+        # saturates at MAX_LOG_LINES and every append front-truncates.
+        self._stdout_total = 0
+        # Dedicated lock for the stdout/stderr buffers + _stdout_total, SEPARATE
+        # from self._lock. The append and the counter bump happen together under
+        # it so wait_for_log() reads a consistent (buffer, total) pair. It is NOT
+        # self._lock on purpose: start() holds self._lock across _spawn_process's
+        # 0.5s probe, and blocking the stream append there would empty the
+        # immediate-exit diagnostic tail.
+        self._buffer_lock = threading.Lock()
         self._players: Dict[str, OnlinePlayer] = {}
         self._lock = threading.Lock()
+        # True only while stop() is draining a still-alive process. stop()
+        # releases the lock during the drain (so stream threads can log shutdown
+        # lines), which makes is_running briefly read False even though the JVM
+        # is still up; start() checks this flag to avoid launching a second
+        # process on the same world during that window.
+        self._stopping = False
 
     def _parse_command(self, command: Optional[Iterable[str]]) -> Optional[List[str]]:
         if command is None:
@@ -219,12 +255,24 @@ class ServerManager:
         if not self._process:
             return
 
-        def _stream(pipe, buffer: List[tuple[str, str]]):
+        def _stream(pipe, buffer: List[tuple[str, str]], is_stdout: bool):
             for line in iter(pipe.readline, ""):
-                buffer.append((iso_z_now(), line))
-                if len(buffer) > self.MAX_LOG_LINES:
-                    del buffer[: len(buffer) - self.MAX_LOG_LINES]
-                join_match = self._PLAYER_JOIN_RE.search(line)
+                # Append + truncate + counter bump together under _buffer_lock
+                # (NOT self._lock) so wait_for_log sees a consistent
+                # (buffer, _stdout_total) snapshot, while start()'s self._lock
+                # hold across the 0.5s spawn probe can't block this append (which
+                # would empty the immediate-exit diagnostic tail).
+                with self._buffer_lock:
+                    buffer.append((iso_z_now(), line))
+                    if len(buffer) > self.MAX_LOG_LINES:
+                        del buffer[: len(buffer) - self.MAX_LOG_LINES]
+                    if is_stdout:
+                        self._stdout_total += 1
+                # Player detection runs on the ANSI-stripped, prefix-anchored
+                # line (the raw line stays in the buffer for the colour console
+                # viewer).
+                clean = self._ANSI_RE.sub("", line)
+                join_match = self._PLAYER_JOIN_RE.search(clean)
                 if join_match:
                     name = join_match.group(1)
                     with self._lock:
@@ -233,20 +281,22 @@ class ServerManager:
                             joined_at=datetime.now(timezone.utc),
                         )
                 else:
-                    leave_match = self._PLAYER_LEAVE_RE.search(line)
+                    leave_match = self._PLAYER_LEAVE_RE.search(clean)
                     if leave_match:
                         with self._lock:
                             self._players.pop(leave_match.group(1), None)
                 print(line, end="")
             pipe.close()
 
-        self._stdout_buffer = []
-        self._stderr_buffer = []
+        with self._buffer_lock:
+            self._stdout_buffer = []
+            self._stderr_buffer = []
+            self._stdout_total = 0
         self._stdout_thread = threading.Thread(
-            target=_stream, args=(self._process.stdout, self._stdout_buffer), daemon=True
+            target=_stream, args=(self._process.stdout, self._stdout_buffer, True), daemon=True
         )
         self._stderr_thread = threading.Thread(
-            target=_stream, args=(self._process.stderr, self._stderr_buffer), daemon=True
+            target=_stream, args=(self._process.stderr, self._stderr_buffer, False), daemon=True
         )
         self._stdout_thread.start()
         self._stderr_thread.start()
@@ -289,6 +339,18 @@ class ServerManager:
         with self._lock:
             if self.is_running:
                 return {"status": "running", "message": "Server is already running"}
+
+            if self._stopping:
+                # A stop() is draining a still-alive JVM (is_running reads False
+                # only because self._process was cleared). Launching now would
+                # put a second process on the same world → corruption. The
+                # "stopping" marker lets the route reject without clobbering the
+                # persisted "stopping" status back to "stopped" mid-drain.
+                return {
+                    "status": "stopped",
+                    "stopping": True,
+                    "message": "Server is still stopping; wait for it to fully stop before starting again",
+                }
 
             command_to_run = self.command
 
@@ -352,6 +414,11 @@ class ServerManager:
             self._players.clear()
             self._stdout_thread = None
             self._stderr_thread = None
+            # Set atomically with clearing self._process so start() (which needs
+            # the same lock) sees a consistent state: either the process is still
+            # present (is_running True) or _stopping is True — never a window
+            # where both look idle. Reset in the finally once the drain is done.
+            self._stopping = True
 
         # Lock released so stream threads can still acquire it while draining
         # shutdown log lines (e.g. player-disconnect events logged on shutdown).
@@ -382,6 +449,8 @@ class ServerManager:
                 stdout_thread.join(timeout=5)
             if stderr_thread:
                 stderr_thread.join(timeout=5)
+            with self._lock:
+                self._stopping = False
 
         return {"status": "stopped", "message": "Server stopped"}
 
@@ -437,38 +506,53 @@ class ServerManager:
     ) -> bool:
         """Wait for a log line matching ``pattern`` to appear after now.
 
-        Snapshots ``len(self._stdout_buffer)`` under the lock, then polls
-        every ``poll_interval`` seconds for any newly-appended stdout line
-        that matches. Lines already in the buffer at call time are ignored
-        — callers want confirmation of an action they just triggered (e.g.
-        ``save-all flush``), not the historical state.
+        Snapshots the monotonic stdout line counter under the lock, then polls
+        every ``poll_interval`` seconds for any newly-appended stdout line that
+        matches. Lines already in the buffer at call time are ignored — callers
+        want confirmation of an action they just triggered (e.g. ``save-all
+        flush``), not the historical state.
 
-        Returns True on match, False on timeout. Uses ``time.monotonic``
-        so a wall-clock jump (NTP adjust, suspend/resume) doesn't extend
-        or truncate the wait.
+        Uses ``self._stdout_total`` (a count that survives the MAX_LOG_LINES
+        front-truncation) rather than absolute buffer indices: once the buffer
+        saturates, its length stops growing, so an absolute ``start_index``
+        would never be exceeded and this would always time out.
+
+        The counter read and the buffer slice are taken together under
+        ``_buffer_lock`` (the same lock _stream appends under) so an interleaved
+        append cannot shift the tail window and make ``seen_total`` skip an
+        unseen line. Returns True on match, False on timeout. Uses
+        ``time.monotonic`` so a wall-clock jump (NTP adjust, suspend/resume)
+        doesn't extend or truncate the wait.
         """
         if isinstance(pattern, str):
             pattern = re.compile(pattern)
 
-        with self._lock:
-            start_index = len(self._stdout_buffer)
+        def _drain_new(seen_total: int):
+            """Return (new lines since seen_total, updated total). Best-effort:
+            if more than MAX_LOG_LINES arrived between polls, only the retained
+            tail is returned. Counter + slice are read atomically under
+            _buffer_lock; the returned slice is a fresh copy safe to iterate
+            after release."""
+            with self._buffer_lock:
+                total = self._stdout_total
+                new = total - seen_total
+                pending = self._stdout_buffer[-new:] if new > 0 else []
+            return pending, total
+
+        with self._buffer_lock:
+            seen_total = self._stdout_total
 
         deadline = time.monotonic() + max(0.0, timeout)
         while time.monotonic() < deadline:
-            with self._lock:
-                # Snapshot the slice under the lock so the streaming
-                # thread can't truncate-then-resize the buffer mid-iter.
-                pending = self._stdout_buffer[start_index:]
-                start_index = len(self._stdout_buffer)
+            pending, seen_total = _drain_new(seen_total)
             for _, line in pending:
                 if pattern.search(line):
                     return True
             time.sleep(poll_interval)
 
-        # One final sweep — covers the race where the matching line
-        # arrives after the last poll-sleep but before timeout.
-        with self._lock:
-            pending = self._stdout_buffer[start_index:]
+        # One final sweep — covers the race where the matching line arrives
+        # after the last poll-sleep but before timeout.
+        pending, _ = _drain_new(seen_total)
         for _, line in pending:
             if pattern.search(line):
                 return True

--- a/backend/server/routes.py
+++ b/backend/server/routes.py
@@ -1,12 +1,15 @@
 """Server management routes and blueprints."""
 from functools import lru_cache
 from pathlib import Path
+import logging
 import os
 import shutil
 import stat
 import threading
 
 from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger(__name__)
 
 from backend.server.registry import get_server_process_registry
 from backend.server import storage
@@ -908,6 +911,15 @@ def start_server_by_id(server_id, server):
     except ValueError as exc:
         return jsonify({'error': str(exc)}), 400
 
+    if result.get('stopping'):
+        # The manager refused because a stop() is still draining (a start that
+        # raced past the status snapshot above). Do NOT write status here — that
+        # would clobber the persisted 'stopping' back to 'stopped' mid-drain.
+        return jsonify({
+            'error': result.get('message', 'Server is stopping. Please wait for it to fully stop.'),
+            'server': _augment_with_runtime(server),
+        }), 409
+
     status_value = result.get('status')
     success = status_value == 'running'
     updated_server = (
@@ -959,8 +971,15 @@ def stop_server_by_id(server_id, server):
     updated_server = storage.update_server_status(server_id, 'stopping') or server
 
     def _stop_worker():
-        result = _registry().stop_server(server_id)
-        storage.update_server_status(server_id, result.get('status', 'stopped'))
+        try:
+            result = _registry().stop_server(server_id)
+            storage.update_server_status(server_id, result.get('status', 'stopped'))
+        except Exception:
+            # Never leave the persisted status stuck at 'stopping' — the manager
+            # clears its own _stopping flag in stop()'s finally, so the JVM is
+            # gone regardless; a stuck 'stopping' would otherwise mislead the UI.
+            logger.exception("Stop worker for server %s failed", server_id)
+            storage.update_server_status(server_id, 'stopped')
 
     threading.Thread(target=_stop_worker, daemon=True).start()
 

--- a/frontend/src/components/modals/ModSideDecisionModal.vue
+++ b/frontend/src/components/modals/ModSideDecisionModal.vue
@@ -217,6 +217,11 @@ async function checkModViaApi(mod, { signal } = {}) {
       ...checks.value,
       [path]: { state: 'error', message: error?.message || 'API check failed.', recommendation: '', serverSide: '', projectTitle: '' }
     }
+    // Re-throw so a caller that wraps this in withBackoff (checkAllViaApi) can
+    // actually retry transient failures (429/503). Previously this was
+    // swallowed, so withBackoff always saw success and never retried. Single
+    // checks catch and ignore it (the per-row error state is already set).
+    throw error
   }
 }
 
@@ -227,7 +232,13 @@ async function checkSingleViaApi(mod) {
   if (!inflightController.value) {
     inflightController.value = new AbortController()
   }
-  await checkModViaApi(mod, { signal: inflightController.value.signal })
+  try {
+    await checkModViaApi(mod, { signal: inflightController.value.signal })
+  } catch {
+    // A single check has no retry; the per-row error/idle state is already
+    // recorded inside checkModViaApi. Swallow the re-thrown error so it doesn't
+    // surface as an unhandled rejection.
+  }
 }
 
 async function checkAllViaApi() {

--- a/frontend/src/views/server/ServerConsolePage.vue
+++ b/frontend/src/views/server/ServerConsolePage.vue
@@ -11,21 +11,47 @@ const activeFilter = ref('ALL')
 const autoScroll = ref(true)
 const terminalRef = ref(null)
 
-const parseLine = (raw) => {
-  const m = raw.match(LEVEL_PATTERN)
+// Render an ISO-Z capture timestamp as HH:MM:SS in the viewer's local timezone.
+// getHours/Minutes/Seconds are local to the browser, so two people in different
+// zones each see their own wall-clock time for the same line.
+const formatLocalTime = (ts) => {
+  if (!ts) return ''
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ''
+  const p = (n) => String(n).padStart(2, '0')
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+}
+
+const parseLine = (entry) => {
+  // Backend now ships { ts, text }; tolerate plain strings from an older
+  // backend during a rolling update.
+  const text = typeof entry === 'string' ? entry : (entry?.text ?? '')
+  const ts = entry && typeof entry === 'object' ? entry.ts : null
+  const m = text.match(LEVEL_PATTERN)
   const level = m ? m[1] : 'INFO'
-  // Try to extract a leading timestamp (e.g., [12:04:01]) — fall back to empty.
-  const tsMatch = raw.match(/\[(\d{2}:\d{2}:\d{2})\]/)
-  const time = tsMatch ? tsMatch[1] : ''
-  return { time, level, message: raw }
+  // Prefer the authoritative capture time (shown in local tz); fall back to any
+  // leading [HH:MM:SS] the server logged itself if no ts is present.
+  let time = formatLocalTime(ts)
+  if (!time) {
+    const tsMatch = text.match(/\[(\d{2}:\d{2}:\d{2})\]/)
+    time = tsMatch ? tsMatch[1] : ''
+  }
+  // Drop the server's own leading [HH:MM:SS] from the message — it's redundant
+  // with the time column (which now shows local time) and would otherwise read
+  // as a confusing double timestamp.
+  const message = text.replace(/^\s*\[\d{2}:\d{2}:\d{2}\]\s*/, '')
+  return { time, level, message }
 }
 
 // Tag each line with a stream-scoped id so :key stays stable across filter
 // toggles — index keys made Vue recycle DOM nodes carrying the previous
 // line's level class, flashing the wrong color on filter swap.
 const allLines = computed(() => {
-  const stdout = (store.logs.stdout || []).map((line, i) => ({ id: `stdout:${i}`, stream: 'stdout', ...parseLine(line) }))
-  const stderr = (store.logs.stderr || []).map((line, i) => ({ id: `stderr:${i}`, stream: 'stderr', level: 'ERROR', time: parseLine(line).time, message: line }))
+  const stdout = (store.logs.stdout || []).map((entry, i) => ({ id: `stdout:${i}`, stream: 'stdout', ...parseLine(entry) }))
+  const stderr = (store.logs.stderr || []).map((entry, i) => {
+    const parsed = parseLine(entry)
+    return { id: `stderr:${i}`, stream: 'stderr', level: 'ERROR', time: parsed.time, message: parsed.message }
+  })
   return [...stdout, ...stderr]
 })
 

--- a/frontend/src/views/server/ServerConsolePage.vue
+++ b/frontend/src/views/server/ServerConsolePage.vue
@@ -5,7 +5,24 @@ import { useServerStore } from '../../stores/server'
 
 const store = useServerStore()
 
-const LEVEL_PATTERN = /\b(ERROR|WARN|INFO|DEBUG)\b/
+// Case-sensitive on purpose: Minecraft/Log4j and the JVM emit these tokens in
+// uppercase (e.g. "[Server thread/WARN]", "WARNING:"), so matching only
+// uppercase avoids false hits on ordinary words in chat/messages.
+const LEVEL_PATTERN = /\b(FATAL|SEVERE|ERROR|WARNING|WARN|INFO|DEBUG|TRACE)\b/
+
+// Collapse the various spellings onto the four levels the UI filters/styles use.
+const normalizeLevel = (raw) => {
+  switch (raw) {
+    case 'FATAL':
+    case 'SEVERE':
+    case 'ERROR':   return 'ERROR'
+    case 'WARNING':
+    case 'WARN':    return 'WARN'
+    case 'DEBUG':
+    case 'TRACE':   return 'DEBUG'
+    default:        return 'INFO'
+  }
+}
 
 const activeFilter = ref('ALL')
 const autoScroll = ref(true)
@@ -22,13 +39,15 @@ const formatLocalTime = (ts) => {
   return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
 }
 
-const parseLine = (entry) => {
+const parseLine = (entry, defaultLevel = 'INFO') => {
   // Backend now ships { ts, text }; tolerate plain strings from an older
   // backend during a rolling update.
   const text = typeof entry === 'string' ? entry : (entry?.text ?? '')
   const ts = entry && typeof entry === 'object' ? entry.ts : null
   const m = text.match(LEVEL_PATTERN)
-  const level = m ? m[1] : 'INFO'
+  // Derive the level from the line itself; fall back to the stream's default
+  // (stderr lines without a recognizable level are treated as errors).
+  const level = m ? normalizeLevel(m[1]) : defaultLevel
   // Prefer the authoritative capture time (shown in local tz); fall back to any
   // leading [HH:MM:SS] the server logged itself if no ts is present.
   let time = formatLocalTime(ts)
@@ -49,8 +68,8 @@ const parseLine = (entry) => {
 const allLines = computed(() => {
   const stdout = (store.logs.stdout || []).map((entry, i) => ({ id: `stdout:${i}`, stream: 'stdout', ...parseLine(entry) }))
   const stderr = (store.logs.stderr || []).map((entry, i) => {
-    const parsed = parseLine(entry)
-    return { id: `stderr:${i}`, stream: 'stderr', level: 'ERROR', time: parsed.time, message: parsed.message }
+    const parsed = parseLine(entry, 'ERROR')
+    return { id: `stderr:${i}`, stream: 'stderr', ...parsed }
   })
   return [...stdout, ...stderr]
 })

--- a/frontend/src/views/server/ServerConsolePage.vue
+++ b/frontend/src/views/server/ServerConsolePage.vue
@@ -59,7 +59,12 @@ const parseLine = (entry, defaultLevel = 'INFO') => {
   // with the time column (which now shows local time) and would otherwise read
   // as a confusing double timestamp.
   const message = text.replace(/^\s*\[\d{2}:\d{2}:\d{2}\]\s*/, '')
-  return { time, level, message }
+  // Numeric sort key. Parse to a millisecond instant rather than comparing the
+  // raw ISO strings lexicographically: iso_z_now() omits the ".ffffff" fraction
+  // when microsecond == 0, so "…:00Z" would sort AFTER "…:00.5Z" as text
+  // ('.' < 'Z') and reverse same-second lines. NaN when ts is absent/unparseable.
+  const tsMs = ts ? Date.parse(ts) : NaN
+  return { tsMs, time, level, message }
 }
 
 // Tag each line with a stream-scoped id so :key stays stable across filter
@@ -71,7 +76,18 @@ const allLines = computed(() => {
     const parsed = parseLine(entry, 'ERROR')
     return { id: `stderr:${i}`, stream: 'stderr', ...parsed }
   })
-  return [...stdout, ...stderr]
+  // Interleave the two streams by capture timestamp so a crash's stderr shows
+  // next to the stdout that produced it, instead of all stderr dumped after all
+  // stdout. Only sort when EVERY line carries a parseable ts — a numeric key
+  // gives a proper total order (transitive), and a STABLE sort keeps
+  // same-instant lines in their per-stream arrival order. If any line lacks a
+  // ts (older backend sending plain strings), skip sorting and fall back to the
+  // previous stdout-then-stderr order rather than risk a non-transitive compare.
+  const merged = [...stdout, ...stderr]
+  if (merged.every((l) => Number.isFinite(l.tsMs))) {
+    merged.sort((a, b) => a.tsMs - b.tsMs)
+  }
+  return merged
 })
 
 const filteredLines = computed(() => {

--- a/frontend/src/views/server/ServerOverviewPage.vue
+++ b/frontend/src/views/server/ServerOverviewPage.vue
@@ -37,7 +37,10 @@ const cpuDisplay = computed(() => {
 })
 const recentLogLines = computed(() => {
   const lines = store.logs.stdout || []
-  return lines.slice(-RECENT_LOG_PREVIEW_LINES)
+  // Entries are { ts, text }; tolerate plain strings from an older backend.
+  return lines
+    .slice(-RECENT_LOG_PREVIEW_LINES)
+    .map((entry) => (typeof entry === 'string' ? entry : (entry?.text ?? '')))
 })
 const modPreview = computed(() => store.installedMods.slice(0, 4))
 

--- a/frontend/src/views/server/ServerPlayersPage.vue
+++ b/frontend/src/views/server/ServerPlayersPage.vue
@@ -170,7 +170,13 @@ async function startReason(name, mode) {
   reasonTarget.value = { name, mode }
   reasonText.value = ''
   await nextTick()
-  reasonInputEl.value?.focus()
+  // The ref lives inside the players v-for, so Vue collects it into an ARRAY —
+  // calling .focus() on the array threw and the input never focused. Only one
+  // reason input is rendered at a time (v-if on the matching row), so focus its
+  // single entry.
+  const el = reasonInputEl.value
+  const input = Array.isArray(el) ? el[0] : el
+  input?.focus()
 }
 
 function cancelReason() {

--- a/tests/test_backups_restore.py
+++ b/tests/test_backups_restore.py
@@ -149,6 +149,77 @@ def test_safety_snapshot_failure_aborts_restore_and_preserves_live(
     )
 
 
+def test_restore_of_running_server_reaches_done_phase(
+    restore_env, monkeypatch, tmp_path
+):
+    """A restore of a server that was RUNNING must end in the terminal 'done'
+    phase, not stay stuck in 'restarting' (which keeps is_active() True and
+    hangs the frontend poll loop forever)."""
+    from backend.backups import progress
+
+    storage = restore_env["storage"]
+    restore = restore_env["restore"]
+    tmp = restore_env["tmp"]
+
+    install = _seed_server(tmp, "srv_running")
+    storage_dir = tmp_path / "store"
+    storage_dir.mkdir()
+    cfg = storage.create_config(
+        "srv_running",
+        {"name": "Run", "storagePath": str(storage_dir), "compress": False},
+    )
+    archive = storage_dir / "snap.tar"
+    _write_plain_tar(archive, {"world/level.dat": "RESTORED"})
+    snap = storage.record_snapshot(
+        "srv_running",
+        {
+            "configId": cfg["id"],
+            "type": "backup",
+            "filePath": str(archive),
+            "fileName": archive.name,
+            "sizeBytes": archive.stat().st_size,
+            "status": "success",
+        },
+    )
+
+    registry = _fake_registry(install)
+    registry.get_status.return_value = {"status": "running"}
+    monkeypatch.setattr(restore, "get_server_process_registry", lambda: registry)
+
+    job_id = progress.generate_job_id("bjr")
+    restore.run_restore(snap["id"], mode="in_place", job_id=job_id)
+
+    registry.start_server.assert_called_once()          # it WAS restarted
+    entry = progress.get(job_id)
+    assert entry.get("phase") == "done", f"restore stuck in {entry.get('phase')!r}"
+    assert not progress.is_active(job_id)
+
+
+def test_safety_snapshot_excludes_nested_storage_subtree(restore_env, tmp_path):
+    """A storagePath nested inside the install tree must be excluded from the
+    safety tar (no recursive self-inclusion of prior backups), while unrelated
+    siblings under the same intermediate dir are still captured."""
+    restore = restore_env["restore"]
+    install = tmp_path / "install"
+    (install / "world").mkdir(parents=True)
+    (install / "world" / "level.dat").write_text("W")
+    nested = install / "data" / "backups"          # storagePath two levels deep
+    nested.mkdir(parents=True)
+    (nested / "old-backup.tar").write_bytes(b"HUGE" * 4096)
+    (install / "data" / "keepme.dat").write_text("KEEP")
+
+    cfg = {"id": "c1", "name": "Nested"}
+    rec = restore._write_safety_snapshot(
+        install_path=install, cfg=cfg, storage_path=nested, server_id="srv_nested_x"
+    )
+
+    with tarfile.open(rec["filePath"]) as tf:
+        names = set(tf.getnames())
+    assert "world/level.dat" in names
+    assert "data/keepme.dat" in names                              # sibling kept
+    assert not any(n.startswith("data/backups") for n in names), names  # storage subtree gone
+
+
 def test_in_place_restore_overlays_and_preserves_extra_files(
     restore_env, monkeypatch, tmp_path
 ):

--- a/tests/test_backups_routes.py
+++ b/tests/test_backups_routes.py
@@ -182,6 +182,38 @@ def test_delete_config_with_purge_unlinks_files(client, env):
     assert not archive.exists()
 
 
+def test_delete_config_purge_default_storage_path_unlinks_files(client, env):
+    """A config with NO storagePath stores archives under the default
+    <install>/backups. Purge must resolve that default and delete them, not
+    silently retain everything (which orphaned every archive on disk)."""
+    install = _seed_server(env["tmp"], "srv_defpurge")
+    storage = env["storage"]
+    cfg = storage.create_config("srv_defpurge", {"name": "DefaultPath"})  # no storagePath
+    backups_dir = install / "backups"
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    archive = backups_dir / "d.tar"
+    archive.write_bytes(b"archive")
+    storage.record_snapshot(
+        "srv_defpurge",
+        {
+            "configId": cfg["id"],
+            "type": "backup",
+            "filePath": str(archive),
+            "fileName": "d.tar",
+            "sizeBytes": archive.stat().st_size,
+            "status": "success",
+        },
+    )
+
+    resp = client.delete(
+        f"/api/servers/srv_defpurge/backup-configs/{cfg['id']}?purge=1"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["deleted_files"] == 1, body
+    assert not archive.exists()
+
+
 def test_delete_config_purge_only_inside_storage_path(client, env):
     """Files OUTSIDE the config's storagePath must never be deleted."""
     inside = env["tmp"] / "inside-store"

--- a/tests/test_backups_scheduler.py
+++ b/tests/test_backups_scheduler.py
@@ -182,3 +182,51 @@ def test_disable_env_var_short_circuits_init(tmp_servers_root, monkeypatch):
     # register_job / remove_job are inert without init.
     assert scheduler_mod.register_job({"id": "bkc_x"}) is None
     assert scheduler_mod.remove_job("bkc_x") is False
+
+
+# ---------------------------------------------------------------------------
+# Trigger timezone alignment (daily CronTrigger uses local time; sub-daily
+# IntervalTrigger must anchor to the SAME local frame, not drift by UTC offset)
+# ---------------------------------------------------------------------------
+
+
+def test_interval_anchor_uses_today_when_slot_still_ahead():
+    from datetime import time as dtime
+    import backend.backups.scheduler as scheduler_mod
+
+    now = datetime(2026, 7, 2, 1, 0)          # 01:00 — 03:30 slot still ahead today
+    anchor = scheduler_mod._interval_anchor(dtime(3, 30), 6, now)
+    assert anchor == datetime(2026, 7, 2, 3, 30)
+    assert anchor.tzinfo == now.tzinfo        # stays in `now`'s frame, not forced to UTC
+
+
+def test_interval_anchor_rolls_forward_when_slot_passed():
+    from datetime import time as dtime
+    import backend.backups.scheduler as scheduler_mod
+
+    now = datetime(2026, 7, 2, 5, 0)          # 05:00 — 03:30 already passed today
+    anchor = scheduler_mod._interval_anchor(dtime(3, 30), 6, now)
+    assert anchor == datetime(2026, 7, 2, 9, 30)   # rolled forward by frequency (6h)
+
+
+def test_subdaily_trigger_anchors_in_local_naive_time(monkeypatch):
+    """_build_trigger must feed a LOCAL (naive) `now` into the anchor — the same
+    frame CronTrigger(hour=, minute=) uses. Previously it passed a UTC-aware
+    datetime, so sub-daily backups fired at the wrong wall-clock time on non-UTC
+    hosts while daily backups fired at local time."""
+    from apscheduler.triggers.interval import IntervalTrigger
+    import backend.backups.scheduler as scheduler_mod
+
+    captured = {}
+    real_anchor = scheduler_mod._interval_anchor
+
+    def spy(time_of_day, frequency_hours, now):
+        captured["now"] = now
+        return real_anchor(time_of_day, frequency_hours, now)
+
+    monkeypatch.setattr(scheduler_mod, "_interval_anchor", spy)
+    trig = scheduler_mod._build_trigger({"frequencyHours": 6, "timeOfDay": "03:30"})
+
+    assert isinstance(trig, IntervalTrigger)
+    assert captured["now"].tzinfo is None, \
+        "sub-daily anchor must use a local (naive) now, not a UTC-aware datetime"

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,76 @@
+"""`fabricator status` CLI: reachability + server summary.
+
+Regression guard: the old code hit a non-existent /api/status (404), so Flask
+looked "up" but the status view only ever printed "no Minecraft data available".
+It now probes /api/health and summarises /api/servers.
+"""
+from unittest.mock import MagicMock
+
+import tools.cli as cli
+
+
+def _resp(ok=True, json_body=None):
+    r = MagicMock()
+    r.ok = ok
+    r.json.return_value = json_body
+    return r
+
+
+def test_collect_status_probes_health_not_status(monkeypatch):
+    calls = []
+
+    def fake_get(url, timeout=None):
+        calls.append(url)
+        if url.endswith("/api/health"):
+            return _resp(ok=True, json_body={"healthy": True})
+        if url.endswith("/api/servers"):
+            return _resp(ok=True, json_body=[
+                {"name": "Alpha", "runtime": {"status": "running"}},
+                {"name": "Beta", "status": "stopped"},
+            ])
+        return _resp(ok=False)
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.subprocess, "run",
+                        lambda *a, **k: MagicMock(stdout="active\n"))
+
+    data = cli._collect_status()
+
+    assert any(u.endswith("/api/health") for u in calls)
+    assert not any(u.endswith("/api/status") for u in calls)  # the old, 404-ing endpoint
+    assert data["flask_up"] is True
+    assert data["systemd_state"] == "active"
+    assert isinstance(data["servers"], list) and len(data["servers"]) == 2
+
+
+def test_collect_status_flask_down_when_health_unreachable(monkeypatch):
+    def boom(url, timeout=None):
+        raise Exception("connection refused")
+
+    monkeypatch.setattr(cli.requests, "get", boom)
+    monkeypatch.setattr(cli.subprocess, "run",
+                        lambda *a, **k: MagicMock(stdout="inactive\n"))
+
+    data = cli._collect_status()
+    assert data["flask_up"] is False
+    assert data["servers"] is None
+
+
+def test_render_status_summarises_running_servers(monkeypatch):
+    lines = []
+    monkeypatch.setattr(cli.click, "echo", lambda msg="": lines.append(msg))
+    monkeypatch.setattr(cli.click, "style", lambda text, **k: text)
+
+    cli._render_status({
+        "systemd_state": "active",
+        "flask_up": True,
+        "servers": [
+            {"name": "Alpha", "runtime": {"status": "running"}},
+            {"name": "Beta", "status": "stopped"},
+        ],
+    })
+
+    joined = "\n".join(lines)
+    assert "Servers:  1/2 running" in joined
+    assert "Alpha" in joined
+    assert "no Minecraft data available" not in joined  # the old, misleading message

--- a/tests/test_java_install_serialize.py
+++ b/tests/test_java_install_serialize.py
@@ -1,0 +1,68 @@
+"""Concurrent installs of the SAME Java major must serialize (they share the
+fixed download path + managed target dir and would corrupt each other), while
+each request stays an independent, independently-cancellable task."""
+import threading
+import time
+from pathlib import Path
+
+from backend.server import java_manager as jm
+
+
+def _reset():
+    with jm._install_tasks_lock:
+        jm._install_tasks.clear()
+        jm._install_task_handles.clear()
+    with jm._major_install_locks_guard:
+        jm._major_install_locks.clear()
+
+
+def test_same_major_installs_do_not_run_concurrently(monkeypatch):
+    state = {"in_download": 0, "max": 0}
+    guard = threading.Lock()
+    first_in = threading.Event()
+    release = threading.Event()
+
+    def fake_download(major, progress_callback=None, cancel_event=None):
+        with guard:
+            state["in_download"] += 1
+            state["max"] = max(state["max"], state["in_download"])
+        first_in.set()
+        release.wait(timeout=5)
+        with guard:
+            state["in_download"] -= 1
+        return Path("/fake/archive.tar.gz")
+
+    monkeypatch.setattr(jm, "download_java", fake_download)
+    monkeypatch.setattr(jm, "install_java", lambda major, archive: "/fake/java")
+
+    _reset()
+    try:
+        id1 = jm.start_install_task(17)
+        assert first_in.wait(timeout=3), "first install never entered download"
+        id2 = jm.start_install_task(17)
+
+        # id2 must be a distinct, independently-cancellable task...
+        assert id2 != id1
+        # ...and must be blocked on the per-major lock, NOT downloading in
+        # parallel with id1 (give its worker a moment to reach the lock).
+        time.sleep(0.3)
+        assert state["max"] == 1, "two same-major installs ran download concurrently"
+
+        release.set()
+
+        # Both tasks reach a terminal state (id2 runs after id1 releases).
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            with jm._install_tasks_lock:
+                pending = [
+                    t for t in jm._install_tasks.values()
+                    if t.get("status") not in jm._TERMINAL_STATUSES
+                ]
+            if not pending:
+                break
+            time.sleep(0.02)
+        assert not pending, "install tasks did not finish"
+        assert state["max"] == 1  # never overlapped
+    finally:
+        release.set()
+        _reset()

--- a/tests/test_players_live.py
+++ b/tests/test_players_live.py
@@ -34,16 +34,101 @@ def test_paper_join_line_matches():
     assert JOIN.search(line) is not None
 
 
-def test_join_ignores_chat_messages_containing_keyword():
-    # Chat messages also flow through INFO but use a different prefix shape.
-    # The regex relies on the "joined the game" tail anchor, not the prefix.
-    line = "[12:34:56] [Server thread/INFO]: <Linus> joined the game now?"
-    # Acceptable false-positive: regex would match "Linus> " here.
-    # Documenting current behavior so a future tightening shows up as a diff.
+def test_join_ignores_chat_message_with_trailing_text():
+    # Chat is logged as "<name> <text>"; a message that merely contains the
+    # keyword must NOT register a join (this used to spoof the online list).
+    line = "[12:34:56] [Server thread/INFO]: <Griefer> haha I just joined the game"
+    assert JOIN.search(line) is None
+
+
+def test_join_ignores_chat_message_exactly_ending_in_keyword():
+    # Even a chat line whose text is exactly "joined the game" must be ignored —
+    # the "<...>" chat prefix is the discriminator.
+    line = "[12:34:56] [Server thread/INFO]: <Griefer> joined the game"
+    assert JOIN.search(line) is None
+
+
+def test_leave_ignores_chat_message_ending_in_keyword():
+    line = "[12:34:56] [Server thread/INFO]: <Griefer> rage quit and left the game"
+    assert LEAVE.search(line) is None
+
+
+def test_join_ignores_unsigned_chat_not_secure_prefix():
+    # Minecraft 1.19+ logs unsigned chat with a "[Not Secure]" prefix before the
+    # "<name>" wrapper — the "[" must not slip past the guard.
+    line = "[12:34:56] [Server thread/INFO]: [Not Secure] <Griefer> I just joined the game"
+    assert JOIN.search(line) is None
+
+
+def test_join_matches_line_with_trailing_whitespace():
+    # The end-anchor tolerates a trailing newline / whitespace on the buffered
+    # line so a real join isn't dropped.
+    line = "[12:34:56] [Server thread/INFO]: Notch joined the game\n"
     m = JOIN.search(line)
-    assert m is not None  # current behavior — name capture is permissive
+    assert m is not None
+    assert m.group(1) == "Notch"
+
+
+def test_join_allows_name_with_space():
+    # Bedrock/Geyser gamertags can contain spaces; a real join line has no chat
+    # "<...>" wrapper, so these must still register (a "\S+" tightening would
+    # wrongly drop them).
+    line = "[12:34:56] [Server thread/INFO]: Cool Gamer joined the game"
+    m = JOIN.search(line)
+    assert m is not None
+    assert m.group(1) == "Cool Gamer"
 
 
 def test_underscores_in_name_match():
     line = "[12:34:56] [Server thread/INFO]: Some_Player joined the game"
     assert JOIN.search(line).group(1) == "Some_Player"
+
+
+def test_join_ignores_embedded_info_prefix_spoof():
+    # A player types "INFO]: Ghost joined the game" into chat. The prefix is
+    # pinned to the line start, so it can't re-anchor onto the embedded marker.
+    line = "[12:34:56] [Server thread/INFO]: <Griefer> INFO]: Ghost joined the game"
+    assert JOIN.search(line) is None
+
+
+def test_leave_ignores_embedded_info_prefix_spoof():
+    line = "[12:34:56] [Server thread/INFO]: <Griefer> INFO]: Notch left the game"
+    assert LEAVE.search(line) is None
+
+
+def test_join_ignores_embedded_bracketed_info_prefix_spoof():
+    # Same attack, but the player includes the brackets: "[x/INFO]: ...".
+    line = "[12:34:56] [Server thread/INFO]: <Griefer> [x/INFO]: Ghost joined the game"
+    assert JOIN.search(line) is None
+
+
+def test_join_matches_legacy_single_bracket_format():
+    # Legacy Bukkit/Spigot/Paper console layout uses a single bracket:
+    # "[HH:MM:SS INFO]: ...".
+    line = "[12:34:56 INFO]: Notch joined the game"
+    m = JOIN.search(line)
+    assert m is not None
+    assert m.group(1) == "Notch"
+
+
+def test_join_ignores_spoof_in_single_bracket_format():
+    line = "[12:34:56 INFO]: <Griefer> INFO]: Ghost joined the game"
+    assert JOIN.search(line) is None
+
+
+def test_join_matches_forge_style_category_line():
+    # Forge/NeoForge add a "[category]" between the thread marker and the colon.
+    line = "[12:34:56] [Server thread/INFO] [minecraft/MinecraftServer]: Notch joined the game"
+    m = JOIN.search(line)
+    assert m is not None
+    assert m.group(1) == "Notch"
+
+
+def test_join_matches_ansi_wrapped_name_after_strip():
+    # Some setups colour the name on the pipe; _stream strips ANSI before match.
+    from backend.server.manager import ServerManager
+    raw = "[12:34:56] [Server thread/INFO]: \x1b[37mNotch\x1b[m joined the game"
+    clean = ServerManager._ANSI_RE.sub("", raw)
+    m = JOIN.search(clean)
+    assert m is not None
+    assert m.group(1) == "Notch"

--- a/tests/test_playit_agent.py
+++ b/tests/test_playit_agent.py
@@ -521,6 +521,161 @@ def test_stop_then_late_reader_does_not_set_error(agent):
 
 
 # ---------------------------------------------------------------------------
+# Self-exit of the daemon: poller must not resurrect it, and must be retired
+# ---------------------------------------------------------------------------
+
+def _rundata_with_tunnel(local_port: str = "25565",
+                         address: str = "alpha.gl.joinmc.link") -> dict:
+    """Build a minimal rundata body that reports one live server-side tunnel."""
+    return {"data": {"tunnels": [{
+        "agent_config": {"fields": [{"name": "local_port", "value": local_port}]},
+        "display_address": address,
+        "name": "Test",
+        "tunnel_type": "minecraft-java",
+    }]}}
+
+
+def test_rundata_does_not_resurrect_exited_daemon(agent):
+    """A daemon that died on its own leaves _status='error' (non-inline tail
+    reason). A late rundata cycle still sees server-side tunnels — it must NOT
+    flip the state back to 'running', because the local daemon is gone."""
+    dead = MagicMock(spec=subprocess.Popen)
+    dead.poll.return_value = 1                     # process has exited
+    with agent._lock:
+        agent._proc = dead
+        agent._status = "error"
+        agent._error_reason = "playitd exited with code 1"
+        agent._apply_rundata_to_state(_rundata_with_tunnel())
+
+    status = agent.get_status()
+    assert status["status"] == "error", f"dead daemon resurrected: {status}"
+    assert status["error_reason"] == "playitd exited with code 1"
+
+
+def test_rundata_sets_running_when_daemon_alive(agent):
+    """Regression guard for the resurrection fix: while the daemon is alive,
+    rundata must still drive 'starting' → 'running' and populate tunnels."""
+    alive = MagicMock(spec=subprocess.Popen)
+    alive.poll.return_value = None                # still running
+    with agent._lock:
+        agent._proc = alive
+        agent._status = "starting"
+        agent._apply_rundata_to_state(_rundata_with_tunnel())
+
+    status = agent.get_status()
+    assert status["status"] == "running"
+    assert status["tunnels"][0]["address"] == "alpha.gl.joinmc.link"
+    assert status["tunnels_known"] is True
+
+
+def test_run_daemon_retires_generation_when_daemon_exits(agent, tmp_path):
+    """When the daemon exits on its own, _run_daemon must advance _gen so the
+    rundata poller spawned for that generation exits (no thread leak, and no
+    chance to resurrect the dead daemon on a later cycle)."""
+    fake = MagicMock(spec=subprocess.Popen)
+    fake.stdout = iter([])                         # EOF at once → daemon exited
+    fake.pid = 4242
+    fake.poll.return_value = 1
+    fake.returncode = 1
+    fake.wait = MagicMock(return_value=1)
+
+    with agent._lock:
+        agent._gen = 7
+
+    started_gens = []
+    with patch("subprocess.Popen", return_value=fake), \
+         patch.object(agent, "_start_rundata_poller",
+                      side_effect=lambda g: started_gens.append(g)):
+        agent._run_daemon(my_gen=7, daemon_bin="/fake/playit",
+                          secret=tmp_path / "secret.toml")
+
+    assert started_gens == [7], "poller should have been started for gen 7"
+    assert agent._gen == 8, "generation must advance so the stale poller exits"
+    assert agent.get_status()["status"] == "error"   # rc=1 → terminal error
+
+
+def test_poller_retires_generation_when_daemon_exited(agent, monkeypatch):
+    """Fallback path: if the daemon exits but the stdout reader is still blocked
+    (a child holds the pipe open, so _run_daemon never bumps _gen), the poller
+    itself must notice the dead process, refuse the stale 'live' rundata, and
+    retire its generation so it stops polling."""
+    dead = MagicMock(spec=subprocess.Popen)
+    dead.poll.return_value = 137                      # exited (OOM-killed)
+    with agent._lock:
+        agent._gen = 3
+        agent._proc = dead
+        agent._status = "running"
+
+    # rundata still reports a live tunnel (playit.gg lags a local exit); the
+    # poller must NOT trust it. Make the cycle instant.
+    monkeypatch.setattr(agent, "_read_secret_for_api", lambda: "a" * 64)
+    monkeypatch.setattr(agent, "_call_rundata", lambda secret: _rundata_with_tunnel())
+    monkeypatch.setattr(agent, "_RUNDATA_INITIAL_BACKOFF", 0)
+
+    t = threading.Thread(target=agent._rundata_poller, args=(3,),
+                         name="playit-rundata-3", daemon=True)
+    t.start()
+    t.join(timeout=3.0)
+
+    assert not t.is_alive(), "poller failed to retire and kept polling a dead daemon"
+    assert agent._gen == 4, "poller must advance _gen to retire the generation"
+    status = agent.get_status()
+    assert status["status"] == "error", "non-zero exit must map to 'error'"
+    assert "137" in (status["error_reason"] or ""), \
+        "error_reason must reflect the daemon's exit code"
+
+
+def test_poller_clean_exit_reports_stopped_not_error(agent, monkeypatch):
+    """A clean daemon self-exit (rc 0) detected by the poller fallback must be
+    reported as 'stopped', not a spurious 'error' — mirroring the reader path's
+    rc-aware classification rather than blindly forcing 'error'."""
+    dead = MagicMock(spec=subprocess.Popen)
+    dead.poll.return_value = 0                         # clean exit
+    with agent._lock:
+        agent._gen = 5
+        agent._proc = dead
+        agent._status = "running"
+
+    monkeypatch.setattr(agent, "_read_secret_for_api", lambda: "a" * 64)
+    monkeypatch.setattr(agent, "_call_rundata", lambda secret: _rundata_with_tunnel())
+    monkeypatch.setattr(agent, "_RUNDATA_INITIAL_BACKOFF", 0)
+
+    t = threading.Thread(target=agent._rundata_poller, args=(5,),
+                         name="playit-rundata-5", daemon=True)
+    t.start()
+    t.join(timeout=3.0)
+
+    assert not t.is_alive()
+    assert agent._gen == 6, "poller must retire the generation on clean exit too"
+    assert agent.get_status()["status"] == "stopped", "clean exit must not be 'error'"
+
+
+def test_poller_transient_error_does_not_run_exited_daemon(agent, monkeypatch):
+    """A transient rundata failure (body=None) must not flip an already-exited
+    daemon from 'starting' to 'running' via the transient window branch."""
+    dead = MagicMock(spec=subprocess.Popen)
+    dead.poll.return_value = 1
+    with agent._lock:
+        agent._gen = 2
+        agent._proc = dead
+        agent._status = "starting"
+
+    monkeypatch.setattr(agent, "_read_secret_for_api", lambda: "a" * 64)
+    monkeypatch.setattr(agent, "_call_rundata", lambda secret: None)   # transient
+    monkeypatch.setattr(agent, "_RUNDATA_INITIAL_BACKOFF", 0)
+
+    t = threading.Thread(target=agent._rundata_poller, args=(2,),
+                         name="playit-rundata-2", daemon=True)
+    t.start()
+    t.join(timeout=3.0)
+
+    assert not t.is_alive()
+    assert agent.get_status()["status"] != "running", \
+        "exited daemon was labeled 'running' via the transient branch"
+    assert agent._gen == 3
+
+
+# ---------------------------------------------------------------------------
 # Reset semantics (Feedback F)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_playit_agent.py
+++ b/tests/test_playit_agent.py
@@ -114,6 +114,42 @@ def test_start_without_cli_binary_sets_error(agent):
     assert "playit-cli binary not found" in status["error_reason"]
 
 
+def test_redundant_start_does_not_reap_own_running_daemon(agent):
+    """A redundant start() while our daemon is alive must NOT reap it — the PID
+    file points at our own healthy daemon, so reaping would kill the live
+    tunnel and defeat the 'already running' fast-return."""
+    reaped = {"called": False}
+    agent._reap_orphan_daemon = lambda: reaped.__setitem__("called", True)
+
+    alive = MagicMock(spec=subprocess.Popen)
+    alive.poll.return_value = None       # daemon is alive
+    alive.pid = 4321
+    with agent._lock:
+        agent._proc = alive
+        agent._status = "running"
+
+    agent.start()
+
+    assert reaped["called"] is False, "start() reaped our own live daemon"
+    assert agent._proc is alive          # daemon left untouched
+    assert agent.get_status()["status"] == "running"
+
+
+def test_start_without_own_daemon_still_reaps_orphan(agent):
+    """When we do NOT own a live daemon, start() must still reap a leftover
+    orphan from a previous run (guard against over-suppressing the reap)."""
+    reaped = {"called": False}
+    agent._reap_orphan_daemon = lambda: reaped.__setitem__("called", True)
+
+    # _proc is None from the fixture. Missing binaries make start() bail right
+    # after the reap.
+    with patch("backend.playit.binary.find_daemon", return_value=None), \
+         patch("backend.playit.binary.find_cli", return_value=None):
+        agent.start()
+
+    assert reaped["called"] is True
+
+
 # ---------------------------------------------------------------------------
 # Happy-path claim + daemon connect
 # ---------------------------------------------------------------------------

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -1,0 +1,103 @@
+"""ServerManager concurrency guards.
+
+- stop()/start() race: during stop()'s unlocked drain, self._process is cleared
+  (is_running reads False) while the JVM is still up; start() must refuse so no
+  second process launches on the same world.
+- wait_for_log() must keep working after the stdout buffer saturates at
+  MAX_LOG_LINES and every append front-truncates (absolute indices stop
+  advancing; a monotonic counter does not).
+"""
+import subprocess
+import threading
+import time
+
+from backend.server.manager import ServerManager
+
+
+def _wait(cond, timeout: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_start_refused_while_stop_is_draining():
+    mgr = ServerManager(cwd=".", command=["true"])
+
+    release = threading.Event()
+
+    class FakeProc:
+        stdin = None
+
+        def poll(self):
+            return None  # still alive throughout the drain
+
+        def wait(self, timeout=None):
+            if not release.wait(timeout):
+                raise subprocess.TimeoutExpired(cmd="server", timeout=timeout)
+            return 0
+
+        def terminate(self):
+            pass
+
+        def kill(self):
+            pass
+
+    mgr._process = FakeProc()
+
+    stopper = threading.Thread(target=mgr.stop, daemon=True)
+    stopper.start()
+    try:
+        assert _wait(lambda: mgr._stopping), "stop() never entered draining state"
+        assert mgr.is_running is False  # process cleared during drain
+        result = mgr.start()
+        assert result["status"] != "running", result
+        assert "stopping" in result["message"].lower()
+    finally:
+        release.set()
+        stopper.join(timeout=5)
+
+    # Once the drain finishes the guard clears and start() is allowed again.
+    assert _wait(lambda: mgr._stopping is False)
+
+
+def test_wait_for_log_matches_after_buffer_saturation():
+    mgr = ServerManager(cwd=".", command=["true"])
+    n = ServerManager.MAX_LOG_LINES
+    with mgr._buffer_lock:
+        mgr._stdout_buffer = [("ts", f"noise {i}\n") for i in range(n)]
+        mgr._stdout_total = n
+
+    def emit():
+        time.sleep(0.05)
+        with mgr._buffer_lock:  # same lock the real _stream append uses
+            mgr._stdout_buffer.append(("ts", "Saved the game\n"))
+            if len(mgr._stdout_buffer) > n:  # front-truncate; length stays at n
+                del mgr._stdout_buffer[: len(mgr._stdout_buffer) - n]
+            mgr._stdout_total += 1
+
+    t = threading.Thread(target=emit)
+    t.start()
+    try:
+        assert mgr.wait_for_log(r"Saved the game", timeout=3.0) is True
+    finally:
+        t.join()
+
+    # Buffer stayed capped — proves the saturation/truncation path was exercised.
+    assert len(mgr._stdout_buffer) == n
+
+
+def test_spawn_process_immediate_exit_captures_stderr_tail():
+    """A process that exits immediately with a stderr diagnostic must surface
+    that tail in the failure message. Regression guard: the stream append must
+    stay lock-free — start()/_spawn_process hold self._lock across the 0.5s
+    probe window, so an append that needed the lock would leave the tail empty
+    and the user would get a bare 'exited immediately (code 1)'."""
+    mgr = ServerManager(cwd=".", command=["true"])
+    cmd = ["sh", "-c", "echo 'Unable to access jarfile server.jar' >&2; exit 1"]
+    with mgr._lock:  # mimic start(), which holds the lock across _spawn_process
+        started, message = mgr._spawn_process(cmd)
+    assert started is False
+    assert "Unable to access jarfile" in message, message

--- a/tests/test_world_import.py
+++ b/tests/test_world_import.py
@@ -274,6 +274,65 @@ def test_running_server_is_stopped_then_restarted(
     registry.start_server.assert_called_once()
 
 
+def test_import_onto_running_server_reaches_done_phase(
+    import_env, monkeypatch, tmp_path
+):
+    """Importing onto a RUNNING server must end in the terminal 'done' phase,
+    not stay stuck in 'restarting' (mirror of the run_restore fix — the same
+    bug lived in run_world_import)."""
+    from backend.backups import progress
+
+    world_import = import_env["world_import"]
+    tmp = import_env["tmp"]
+    install = _seed_server(tmp, "srv_imprun")
+
+    archive = tmp_path / "up.zip"
+    _zip(archive, {"world/level.dat": "IMPORTED"})
+
+    registry = _fake_registry(install)
+    registry.get_status.return_value = {"status": "running"}
+    monkeypatch.setattr(
+        world_import, "get_server_process_registry", lambda: registry
+    )
+
+    job_id = progress.generate_job_id("bjw")
+    world_import.run_world_import(
+        "srv_imprun", archive, original_name="up.zip", job_id=job_id
+    )
+
+    registry.start_server.assert_called_once()          # it WAS restarted
+    entry = progress.get(job_id)
+    assert entry.get("phase") == "done", f"import stuck in {entry.get('phase')!r}"
+    assert not progress.is_active(job_id)
+
+
+def test_import_drops_stale_dimension_dirs(import_env, monkeypatch, tmp_path):
+    """Replace semantics: importing a world with only an overworld must remove
+    the previous world's Nether/End dirs, not leave them live (which produces a
+    mismatched world)."""
+    world_import = import_env["world_import"]
+    tmp = import_env["tmp"]
+    install = _seed_server(tmp, "srv_dims")
+    # Pre-existing live dimensions from the OLD (larger) world.
+    for d in ("world_nether", "world_the_end"):
+        (install / d).mkdir(parents=True, exist_ok=True)
+        (install / d / "marker").write_text("OLD", encoding="utf-8")
+
+    archive = tmp_path / "ow-only.zip"
+    _zip(archive, {"world/level.dat": "NEW-OW", "world/region/r.0.0.mca": "C"})
+
+    registry = _fake_registry(install)
+    monkeypatch.setattr(
+        world_import, "get_server_process_registry", lambda: registry
+    )
+
+    world_import.run_world_import("srv_dims", archive, original_name="ow-only.zip")
+
+    assert (install / "world" / "level.dat").read_text() == "NEW-OW"
+    assert not (install / "world_nether").exists(), "stale nether dir not removed"
+    assert not (install / "world_the_end").exists(), "stale end dir not removed"
+
+
 # ---------------------------------------------------------------------------
 # Upload streaming + validation
 # ---------------------------------------------------------------------------

--- a/tests/test_world_import.py
+++ b/tests/test_world_import.py
@@ -304,6 +304,16 @@ def test_validate_accepts_world_archive(import_env, tmp_path):
     assert world_import.validate_upload_archive(archive) == "zip"
 
 
+def test_validate_accepts_world_archive_with_root_level_dat(import_env, tmp_path):
+    """A zip of the world folder's CONTENTS — level.dat at the archive root — is
+    a valid world. _find_level_dat_root returns "" (not None) for that layout,
+    so a truthiness check would wrongly reject this common packaging."""
+    world_import = import_env["world_import"]
+    archive = tmp_path / "rootworld.zip"
+    _zip(archive, {"level.dat": "x", "region/r.0.0.mca": "y"})
+    assert world_import.validate_upload_archive(archive) == "zip"
+
+
 # ---------------------------------------------------------------------------
 # HTTP route (POST /api/servers/<id>/world-import)
 # ---------------------------------------------------------------------------

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -126,25 +126,32 @@ def _collect_status() -> dict:
     systemd_state = result.stdout.strip() or "unknown"
 
     flask_up = False
-    api_status_code: int | None = None
-    api_body: dict | None = None
+    servers: "list | None" = None
 
+    # /api/health is the always-available liveness endpoint (open even in the
+    # setup/locked states). The old code hit a non-existent /api/status, which
+    # the catch-all turned into a JSON 404 — so Flask looked "up" but the status
+    # view could never show anything useful.
     try:
-        resp = requests.get(f"{API_BASE}/api/status", timeout=5)
-        flask_up = True
-        api_status_code = resp.status_code
-        try:
-            api_body = resp.json()
-        except Exception:
-            api_body = None
+        health = requests.get(f"{API_BASE}/api/health", timeout=5)
+        flask_up = bool(health.ok)
     except Exception:
-        pass
+        flask_up = False
+
+    if flask_up:
+        try:
+            resp = requests.get(f"{API_BASE}/api/servers", timeout=5)
+            if resp.ok:
+                body = resp.json()
+                if isinstance(body, list):
+                    servers = body
+        except Exception:
+            servers = None
 
     return {
         "systemd_state": systemd_state,
         "flask_up": flask_up,
-        "api_status_code": api_status_code,
-        "api_body": api_body,
+        "servers": servers,
     }
 
 
@@ -160,16 +167,18 @@ def _render_status(data: dict) -> None:
 
     click.echo(f"Flask:    {click.style('up', fg='green')}")
 
-    body = data.get("api_body") or {}
-    mc_keys = {"players", "tps", "uptime"}
-    mc_data = {k: v for k, v in body.items() if k in mc_keys}
+    servers = data.get("servers")
+    if servers is None:
+        click.echo("  (could not read the server list)")
+        return
 
-    if mc_data:
-        for key, value in mc_data.items():
-            click.echo(f"  {key}: {value}")
-    else:
-        code = data.get("api_status_code")
-        click.echo(f"  (API returned HTTP {code} — no Minecraft data available)")
+    def _running(server: dict) -> bool:
+        return ((server.get("runtime") or {}).get("status") or server.get("status")) == "running"
+
+    running = [s for s in servers if _running(s)]
+    click.echo(f"Servers:  {len(running)}/{len(servers)} running")
+    for server in running:
+        click.echo(f"  • {server.get('name') or server.get('id') or '?'}")
 
 
 @cli.command()

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -243,9 +243,11 @@ main() {
             return 0
         fi
 
-        # Drift detection: if both binaries already present and matching, skip download in install mode.
-        if [[ "$MODE" != "update" \
-              && -x /usr/local/bin/playit \
+        # Drift detection: if both binaries are already present and match the
+        # pinned sha256, skip the download entirely. This applies to updates too
+        # (the pin only moves when PLAYIT_VERSION is bumped), so a routine update
+        # doesn't re-fetch ~unchanged binaries from GitHub every time.
+        if [[ -x /usr/local/bin/playit \
               && -x /usr/local/bin/playit-cli ]]; then
             if echo "${daemon_sha}  /usr/local/bin/playit" | sha256sum -c - >/dev/null 2>&1 \
                && echo "${cli_sha}  /usr/local/bin/playit-cli" | sha256sum -c - >/dev/null 2>&1; then
@@ -412,8 +414,17 @@ main() {
     fi
 
     # 4a) Setup Python venv + requirements
-    info "Creating Python virtualenv..."
-    run_as_service_user python3 -m venv "$VENV_DIR"
+    # Reuse an existing venv across updates instead of recreating it: a fresh
+    # `python3 -m venv` plus a full dependency reinstall on every update is the
+    # main reason an update drags on (and risks the systemd start timeout). When
+    # the venv is already there, pip's "already satisfied" fast path skips most
+    # of the work and only changed/new requirements are installed.
+    if [ -x "$VENV_DIR/bin/python" ]; then
+        info "Reusing existing Python virtualenv at $VENV_DIR"
+    else
+        info "Creating Python virtualenv..."
+        run_as_service_user python3 -m venv "$VENV_DIR"
+    fi
     run_as_service_user "$VENV_DIR/bin/pip" install --upgrade pip </dev/null
 
     if [ -f "$APP_DIR/requirements.txt" ]; then
@@ -534,6 +545,12 @@ Description=Fabricator self-update job
 
 [Service]
 Type=oneshot
+# A full update recreates the venv and reinstalls every Python dependency
+# (and re-downloads playit), which routinely takes minutes on slower hosts
+# like a Raspberry Pi. Without this, the oneshot inherits DefaultTimeoutStartSec
+# (~90s); systemd would SIGTERM the installer mid-pip and the panel would report
+# a "failed" update that was only killed for being slow.
+TimeoutStartSec=infinity
 # The panel can only write the request file's *contents*; update.sh validates
 # them against a strict allowlist before trusting the version string.
 Environment=FABRICATOR_UPDATE_REQUEST_FILE=${UPDATE_REQUEST_FILE}


### PR DESCRIPTION
  ### Backups
  - World import no longer rejects archives with `level.dat` at the root (a very
    common way people zip a world).
  - World import removes the previous world's stale Nether/End dirs instead of
    leaving a mismatched world behind.
  - Restore / world-import jobs now reach a terminal state instead of getting stuck
    on "restarting" and hanging the progress UI forever.
  - The mandatory safety snapshot no longer packs prior backups into itself when
    the storage path is nested inside the install dir.
  - `?purge=1` on a default-path backup config now actually deletes the archives
    instead of silently leaving them on disk.
  - Sub-daily and daily backup schedules now fire at the same local wall-clock time
    (no more UTC-offset drift).

  ### Server
  - Stopping then immediately starting a server can no longer launch a second JVM
    on the same world (world-corruption race).
  - The "Saved the game" backup-flush confirmation no longer times out once the
    console log buffer fills up (10k lines).
  - The online-player list can no longer be spoofed by chat messages (e.g.
    `<player> ... joined the game`); join/leave parsing now handles vanilla, Paper,
    Fabric, Forge, legacy single-bracket, and colour (ANSI) output.

  ### Java
  - Two installs of the same Java version at once no longer corrupt each other —
    they're serialized per version, each still independently cancellable.

  ### playit
  - A dead/crashed tunnel is no longer reported as "running".
  - Clicking start again while the tunnel is already up no longer kills and
    restarts the healthy daemon.

  ### CLI
  - `fabricator status` now talks to a real endpoint (`/api/health` + `/api/servers`)
    and shows running servers, instead of always printing an HTTP 404.

  ### Frontend
  - "Check All via API" now retries rate-limited (429/503) mods instead of giving up.
  - The console interleaves stdout and stderr in chronological order instead of
    dumping all stderr at the bottom.
  - The kick/ban reason box now focuses when it opens.
