### PR TITLE
Docker - Stream logs to stdout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,17 @@ CORS_ORIGINS=http://localhost:3000
 # playit.gg so the server is reachable without port-forwarding.
 PLAYIT_ENABLED=false
 
+# Configure python to use unbuffered logs. This allows python to stream logs to 
+# stdout so they get picked up by the docker logs command when running Fabricator
+# in a container.  The default value is 1, so most users will not need to change
+# this when running Fabricator in Docker.
+
+# If this variable is set to PYTHONUNBUFFERED=0, then fabricator logs will not be
+# streamed to stdout. Logs will be periodically flushed to stdout, but admins
+# will not be able to view the logs in real time, and any buffered logs will be lost
+# if the container is stopped.
+PYTHONUNBUFFERED=1
+
 # --- Built-in panel authentication ---
 # Auth is ON by default. On first boot with no credential the app starts in a
 # locked SETUP MODE and serves a one-time setup page where you set the operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ ENV FLASK_ENV=production \
     SERVER_INDEX_FILE=/data/servers.json \
     JAVA_ROOT=/data/java \
     BACKUPS_DIR=/data/backups \
-    PLAYIT_RUNTIME_DIR=/data/playit
+    PLAYIT_RUNTIME_DIR=/data/playit \
+    PYTHONUNBUFFERED=1
 # Every persistent path is pinned onto /data (the only VOLUME). FLASK_ENV=
 # production otherwise hardcodes them under /var/lib/fabricator (off-volume,
 # ephemeral). FABRICATOR_APPDATA is deliberately NOT set: ProductionConfig


### PR DESCRIPTION
Configure the dockerfile with a new environmental variable unbuffer the python logs so they are streamed to stdout. This enables docker to pick up the application logs and display them using the docker logs command.

Tested in my home lab by building a new container with the updated dockerfile and running the docker logs command.

Resolution to issue #34.