### PR TITLE
feat(server): add safe vanilla and paper upgrades

### DIFF
--- a/backend/auth/buckets.py
+++ b/backend/auth/buckets.py
@@ -101,6 +101,9 @@ _NEVER = [
     ("DELETE", "/api/servers/<server_id>/backup-configs/<config_id>"),
     ("POST", "/api/servers/<server_id>/backup-configs/<config_id>/run"),
     ("POST", "/api/servers/<server_id>/backup-quick"),
+    # full-server migration is intentionally UI-only until a dedicated MCP tool
+    # can present its backup and rollback contract.
+    ("POST", "/api/servers/<server_id>/upgrade"),
     # modpack install (can plant files including an @args_file)
     ("POST", "/api/modrinth/modpack/<project_id>/install"),
     # .mrpack upload surface: the caller supplies the archive outright, so the

--- a/backend/server/routes.py
+++ b/backend/server/routes.py
@@ -20,6 +20,7 @@ from backend.server.manager import ServerManager
 from backend.server.registry import get_server_process_registry
 from backend.server import storage
 from backend.server import install_progress
+from backend.server import upgrade as upgrade_service
 from backend.managed import is_managed
 from backend.server.installer import (
     InstallStatus,
@@ -1178,6 +1179,68 @@ def install_server(server_id, server):
     ).start()
 
     # Return current progress (includes the 'starting' entry we just inserted).
+    return jsonify({
+        'active': install_progress.is_active(server_id),
+        **install_progress.get(server_id),
+    }), 202
+
+
+@server_bp.route('/servers/<server_id>/upgrade', methods=['POST'])
+@require_server
+def upgrade_server(server_id, server):
+    """Queue a safe Vanilla/Paper release upgrade.
+
+    The worker makes a mandatory full-server snapshot before stopping the JVM or
+    replacing its jar. It shares the established install-progress protocol so
+    callers can use the existing polling endpoint while the migration runs.
+    """
+    payload = request.get_json(silent=True) or {}
+    if not isinstance(payload, dict):
+        return jsonify({'error': 'Request body must be a JSON object'}), 400
+    target_version = payload.get('version')
+    try:
+        target_version = upgrade_service.validate_upgrade(server, target_version)
+    except upgrade_service.UpgradeError as exc:
+        return jsonify({'error': str(exc)}), 400
+
+    if install_progress.is_active(server_id):
+        return jsonify({'error': 'Another operation is in progress for this server'}), 409
+    probe = try_acquire(server_id)
+    if probe is None:
+        return jsonify({'error': 'Another operation is in progress for this server'}), 409
+    probe.release()
+
+    install_progress.update(
+        server_id,
+        phase='starting',
+        server_id=server_id,
+        kind='upgrade',
+        from_version=server.get('version'),
+        to_version=target_version,
+    )
+
+    def _run_upgrade():
+        try:
+            def _on_progress(phase, detail):
+                install_progress.update(server_id, phase=phase, kind='upgrade', **detail)
+
+            result = upgrade_service.upgrade_server(
+                server_id, target_version, progress_callback=_on_progress,
+            )
+            install_progress.update(
+                server_id, phase='done', kind='upgrade', **result,
+            )
+        except Exception as exc:  # surfaced to the polling client
+            logger.exception('Server upgrade failed for %s', server_id)
+            install_progress.update(
+                server_id, phase='failed', kind='upgrade', error=str(exc),
+            )
+
+    threading.Thread(
+        target=_run_upgrade,
+        name=f'server-upgrade-{server_id}',
+        daemon=True,
+    ).start()
     return jsonify({
         'active': install_progress.is_active(server_id),
         **install_progress.get(server_id),

--- a/backend/server/upgrade.py
+++ b/backend/server/upgrade.py
@@ -1,0 +1,188 @@
+"""Safe, first-stage Minecraft server upgrades.
+
+This stage supports the jar-only server types whose upgrade layout is stable:
+Vanilla and Paper. It deliberately refuses modded loaders. An upgrade always
+creates an ad-hoc full-server snapshot before stopping the server or replacing
+``server.jar``; restoring that snapshot is the recovery path if Minecraft's
+world migration is not acceptable.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from backend.backups import service as backup_service
+from backend.server import storage as server_storage
+from backend.server.installer import get_installer_for
+from backend.server.locks import get_server_lock
+from backend.server.registry import get_server_process_registry
+
+_SUPPORTED_LOADERS = frozenset({"vanilla", "paper"})
+_RELEASE_VERSION_RE = re.compile(r"^1\.(\d+)(?:\.(\d+))?$")
+ProgressCallback = Callable[[str, Dict[str, Any]], None]
+
+
+class UpgradeError(ValueError):
+    """A request that cannot safely be performed as a stage-one upgrade."""
+
+
+def _preserve_server_jar(install_path: Path) -> Path | None:
+    """Copy the runnable jar aside before an installer touches its destination.
+
+    Both stage-one installers download straight to ``server.jar`` and remove a
+    failed target download. Keeping this small local rollback copy means a
+    transient download/integrity failure never turns a working server into an
+    unstartable one while the full snapshot remains the wider recovery option.
+    """
+    original = install_path / "server.jar"
+    if not original.is_file():
+        return None
+    rollback = install_path / ".fabricator-server.jar.before-upgrade"
+    try:
+        shutil.copy2(original, rollback)
+    except OSError as exc:
+        raise UpgradeError(f"Could not preserve the current server.jar: {exc}") from exc
+    return rollback
+
+
+def _restore_server_jar(rollback: Path | None, install_path: Path) -> None:
+    if rollback is None:
+        return
+    try:
+        shutil.copy2(rollback, install_path / "server.jar")
+    except OSError as exc:
+        raise UpgradeError(
+            f"Upgrade failed and Fabricator could not restore the previous server.jar: {exc}"
+        ) from exc
+
+
+def _discard_rollback_jar(rollback: Path | None) -> None:
+    if rollback is None:
+        return
+    try:
+        rollback.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _release_version_key(version: object) -> tuple[int, int]:
+    """Convert a stable Minecraft release into a comparable tuple.
+
+    Snapshots, release candidates, and non-release legacy version names are
+    intentionally unsupported in the first release. They require semantics
+    beyond the safe one-way release-to-release migration offered here.
+    """
+    value = str(version or "").strip()
+    match = _RELEASE_VERSION_RE.fullmatch(value)
+    if not match:
+        raise UpgradeError(
+            "Upgrades currently require stable Minecraft release versions "
+            "such as 1.20.1 or 1.21."
+        )
+    return int(match.group(1)), int(match.group(2) or 0)
+
+
+def validate_upgrade(server: Dict[str, Any], target_version: object) -> str:
+    """Validate the non-destructive prerequisites for an upgrade request."""
+    loader = str(server.get("loader") or "").strip().lower()
+    if loader not in _SUPPORTED_LOADERS:
+        raise UpgradeError(
+            "The first upgrade stage only supports vanilla and Paper servers."
+        )
+
+    current_version = str(server.get("version") or "").strip()
+    target = str(target_version or "").strip()
+    current_key = _release_version_key(current_version)
+    target_key = _release_version_key(target)
+    if target_key <= current_key:
+        raise UpgradeError(
+            f"Target Minecraft version must be newer than the current "
+            f"version ({current_version}). Downgrades are not supported."
+        )
+    return target
+
+
+def upgrade_server(
+    server_id: str,
+    target_version: object,
+    *,
+    progress_callback: Optional[ProgressCallback] = None,
+) -> Dict[str, Any]:
+    """Back up, stop, replace the server jar, then persist the new version.
+
+    The function is synchronous so an async route can own the worker lifecycle.
+    It holds the existing per-server RLock across the complete operation; the
+    nested backup call is safe because the lock is re-entrant in this thread.
+    """
+    server = server_storage.get_server(server_id)
+    if not server:
+        raise UpgradeError("Server not found")
+    target = validate_upgrade(server, target_version)
+    previous_version = str(server["version"])
+
+    lock = get_server_lock(server_id)
+    with lock:
+        # Re-read after acquiring the lock so a settings edit cannot change the
+        # loader/version between request validation and the destructive phase.
+        server = server_storage.get_server(server_id)
+        if not server:
+            raise UpgradeError("Server not found")
+        target = validate_upgrade(server, target)
+        previous_version = str(server["version"])
+
+        registry = get_server_process_registry()
+        install_path = registry.resolve_install_path(server)
+        installer = get_installer_for(str(server["loader"]), install_path)
+        if installer is None:  # defensive; validate_upgrade already gates it
+            raise UpgradeError("No installer is available for this server")
+
+        if progress_callback:
+            progress_callback("creating_backup", {"from_version": previous_version})
+        snapshot = backup_service.run_adhoc_backup(
+            server_id,
+            # An upgrade snapshot must capture the whole server directory. The
+            # default location stays inside it, where backup service avoids
+            # recursively archiving its own output.
+            compress=True,
+            flush=True,
+            shutdown=False,
+            trigger="upgrade",
+        )
+
+        if progress_callback:
+            progress_callback("stopping_server", {})
+        registry.stop_server(server_id)
+        rollback_jar = _preserve_server_jar(install_path)
+
+        def _installer_progress(phase: str, detail: Dict[str, Any]) -> None:
+            if progress_callback:
+                progress_callback(phase, detail)
+
+        try:
+            # Do not call install_with_config: it regenerates server.properties
+            # and would overwrite user-edited settings. Vanilla/Paper install()
+            # only replaces server.jar and refreshes the EULA.
+            result = installer.install(target, progress_callback=_installer_progress)
+            if not result.success:
+                raise UpgradeError(result.message)
+
+            updates: Dict[str, Any] = {"version": target, "status": "stopped"}
+            if result.launch is not None:
+                updates["launch"] = result.launch.to_dict()
+            server_storage.update_server(server_id, updates)
+        except Exception:
+            _restore_server_jar(rollback_jar, install_path)
+            raise
+        else:
+            _discard_rollback_jar(rollback_jar)
+
+        if progress_callback:
+            progress_callback("done", {"snapshot_id": snapshot.get("id")})
+        return {
+            "server_id": server_id,
+            "from_version": previous_version,
+            "to_version": target,
+            "snapshot_id": snapshot.get("id"),
+        }

--- a/frontend/src/api/servers.js
+++ b/frontend/src/api/servers.js
@@ -222,6 +222,17 @@ export async function getServerInstallProgress(serverId) {
 }
 
 /**
+ * Create a mandatory snapshot and upgrade a Vanilla or Paper server release.
+ * The returned job uses the normal install-progress endpoint for polling.
+ * @param {string|number} serverId
+ * @param {string} version Target Minecraft release, newer than the current one
+ * @returns {Promise<Object>} Upgrade job state
+ */
+export async function upgradeServer(serverId, version) {
+  return post(`/api/servers/${encodeURIComponent(serverId)}/upgrade`, { version })
+}
+
+/**
  * Get Minecraft versions supported by a loader.
  * @param {string} loader - Loader name (e.g. 'fabric', 'vanilla')
  * @returns {Promise<Array<{version: string, stable: boolean, type?: string}>>}

--- a/frontend/src/views/server/ServerSettingsPage.vue
+++ b/frontend/src/views/server/ServerSettingsPage.vue
@@ -6,10 +6,79 @@ import Panel from '../../components/ui/Panel.vue'
 import ToggleRow from '../../components/ui/ToggleRow.vue'
 import { useServerStore } from '../../stores/server'
 import { useAuthStore } from '../../stores/auth'
-import { getInstalledJava, getJavaStatus } from '../../api/servers'
+import { getInstalledJava, getJavaStatus, getLoaderGameVersions, getServerInstallProgress, upgradeServer } from '../../api/servers'
+import { useToast } from '../../composables/useToast'
 
 const store = useServerStore()
 const auth = useAuthStore()
+const toast = useToast()
+
+// First-stage migrations are deliberately limited to jar-only server types.
+// Fabric/Forge/NeoForge need per-mod compatibility resolution before they can
+// be safely offered here.
+const canUpgrade = computed(() => ['vanilla', 'paper'].includes(store.server?.loader))
+const upgradeVersions = ref([])
+const targetUpgradeVersion = ref('')
+const upgradeStarting = ref(false)
+const upgradePhase = ref('')
+
+function isNewerMinecraftRelease(candidate, current) {
+  const parse = (version) => String(version).split('.').map(Number)
+  const [candidateMajor, candidateMinor, candidatePatch = 0] = parse(candidate)
+  const [currentMajor, currentMinor, currentPatch = 0] = parse(current)
+  return candidateMajor === currentMajor && (
+    candidateMinor > currentMinor ||
+    (candidateMinor === currentMinor && candidatePatch > currentPatch)
+  )
+}
+
+async function loadUpgradeVersions() {
+  if (!canUpgrade.value) return
+  try {
+    const versions = await getLoaderGameVersions(store.server.loader)
+    const current = store.server.version
+    upgradeVersions.value = (versions || [])
+      .filter((entry) => entry.stable && isNewerMinecraftRelease(entry.version, current))
+      .map((entry) => entry.version)
+    targetUpgradeVersion.value = upgradeVersions.value[0] || ''
+  } catch {
+    upgradeVersions.value = []
+  }
+}
+
+async function startUpgrade() {
+  const target = targetUpgradeVersion.value
+  if (!target || !store.server?.id) return
+  const confirmed = window.confirm(
+    `Create a full backup and upgrade ${store.server.name} from ${store.server.version} to ${target}? ` +
+    'Downgrades are not supported; restore the new backup if you need to go back.'
+  )
+  if (!confirmed) return
+  upgradeStarting.value = true
+  upgradePhase.value = 'starting'
+  try {
+    await upgradeServer(store.server.id, target)
+    toast.info('Upgrade started. Fabricator is creating a full backup before replacing the server version.')
+    let progress
+    do {
+      progress = await getServerInstallProgress(store.server.id)
+      upgradePhase.value = progress?.phase || 'working'
+      if (progress?.active) await new Promise((resolve) => setTimeout(resolve, 1000))
+    } while (progress?.active)
+
+    if (progress?.phase === 'done') {
+      await store.loadServer({ silent: true })
+      toast.success(`Server upgraded to ${target}. Your pre-upgrade backup is ready to restore if needed.`)
+    } else {
+      toast.error(progress?.error || 'The server upgrade failed. Your pre-upgrade backup is available for restore.')
+    }
+  } catch (error) {
+    toast.error(error?.message || 'Could not start the server upgrade.')
+  } finally {
+    upgradeStarting.value = false
+    upgradePhase.value = ''
+  }
+}
 
 const isDirty = computed(() => store.isDirtySettings)
 
@@ -140,6 +209,7 @@ const javaAutoHint = computed(() =>
 
 onMounted(async () => {
   if (auth.managed) return
+  await loadUpgradeVersions()
   try {
     const payload = await getInstalledJava()
     installedJava.value = Array.isArray(payload?.managed) ? payload.managed : []
@@ -191,6 +261,36 @@ const onReset = () => {
     <div class="settings-page__guard" v-if="!store.canEditSettings">
       Stop the server before editing configuration.
     </div>
+
+    <Panel v-if="canUpgrade && !auth.managed" title="Minecraft version upgrade">
+      <div class="settings-page__mode">
+        <div>
+          <p class="settings-page__mode-label">Upgrade {{ store.server?.version }}</p>
+          <p class="settings-page__mode-description">
+            Fabricator creates a full backup, stops the server, and installs the selected Vanilla or Paper release. Downgrades are blocked.
+          </p>
+          <p v-if="upgradeStarting" class="settings-page__upgrade-progress">Working: {{ upgradePhase.replaceAll('_', ' ') }}</p>
+        </div>
+        <div class="settings-page__upgrade-actions">
+          <select
+            v-model="targetUpgradeVersion"
+            class="settings-page__input"
+            :disabled="upgradeStarting || !upgradeVersions.length"
+            aria-label="Target Minecraft version"
+          >
+            <option v-for="version in upgradeVersions" :key="version" :value="version">{{ version }}</option>
+          </select>
+          <AppButton
+            variant="warning"
+            :loading="upgradeStarting"
+            :disabled="!targetUpgradeVersion"
+            @click="startUpgrade"
+          >
+            Upgrade server
+          </AppButton>
+        </div>
+      </div>
+    </Panel>
 
     <Panel title="Mode">
       <div class="settings-page__mode">
@@ -1214,6 +1314,25 @@ const onReset = () => {
 .settings-page__mode-button--active {
   border-color: var(--primary);
   color: var(--primary);
+}
+
+.settings-page__upgrade-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 210px;
+}
+
+.settings-page__upgrade-progress {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  margin: var(--space-2) 0 0;
+  text-transform: capitalize;
+}
+
+.settings-page__upgrade-actions .settings-page__input {
+  width: auto;
+  min-width: 104px;
 }
 
 .settings-page__grid {

--- a/tests/test_server_upgrade.py
+++ b/tests/test_server_upgrade.py
@@ -1,0 +1,176 @@
+"""Safety contract tests for the vanilla/Paper server upgrade service."""
+from types import SimpleNamespace
+
+import pytest
+
+from backend.server.installer import InstallResult, InstallStatus, LaunchSpec
+
+
+def _server(**overrides):
+    server = {
+        "id": "srv_upgrade",
+        "loader": "vanilla",
+        "version": "1.20.1",
+        "status": "running",
+    }
+    server.update(overrides)
+    return server
+
+
+def test_upgrade_backs_up_stops_and_only_then_replaces_server_version(monkeypatch, tmp_path):
+    from backend.server import upgrade
+
+    server = _server()
+    events = []
+    updates = []
+
+    class Registry:
+        def resolve_install_path(self, record):
+            assert record == server
+            return tmp_path
+
+        def stop_server(self, server_id):
+            events.append(("stop", server_id))
+            return {"status": "stopped"}
+
+    result = InstallResult(
+        success=True,
+        status=InstallStatus.COMPLETED,
+        message="installed",
+        launch=LaunchSpec(type="jar", jar="server.jar", program_args=["nogui"]),
+    )
+
+    class Installer:
+        def install(self, mc_version, progress_callback=None):
+            events.append(("install", mc_version))
+            return result
+
+    monkeypatch.setattr(upgrade.server_storage, "get_server", lambda _id: server)
+    monkeypatch.setattr(upgrade, "get_server_process_registry", lambda: Registry())
+    monkeypatch.setattr(
+        upgrade.backup_service,
+        "run_adhoc_backup",
+        lambda server_id, **kwargs: events.append(("backup", server_id)) or {"id": "snap_1"},
+    )
+    monkeypatch.setattr(upgrade, "get_installer_for", lambda loader, path: Installer())
+    monkeypatch.setattr(
+        upgrade.server_storage,
+        "update_server",
+        lambda server_id, patch: updates.append((server_id, patch)) or {**server, **patch},
+    )
+
+    upgraded = upgrade.upgrade_server("srv_upgrade", "1.21")
+
+    assert events == [
+        ("backup", "srv_upgrade"),
+        ("stop", "srv_upgrade"),
+        ("install", "1.21"),
+    ]
+    assert upgraded["from_version"] == "1.20.1"
+    assert upgraded["to_version"] == "1.21"
+    assert updates == [
+        (
+            "srv_upgrade",
+            {
+                "version": "1.21",
+                "launch": result.launch.to_dict(),
+                "status": "stopped",
+            },
+        )
+    ]
+
+
+def test_upgrade_restores_original_jar_when_install_fails(monkeypatch, tmp_path):
+    from backend.server import upgrade
+
+    server = _server(status="stopped")
+    jar_path = tmp_path / "server.jar"
+    jar_path.write_bytes(b"known-good-old-server")
+
+    class Registry:
+        def resolve_install_path(self, record):
+            return tmp_path
+
+        def stop_server(self, server_id):
+            return {"status": "stopped"}
+
+    class FailingInstaller:
+        def install(self, mc_version, progress_callback=None):
+            # Mirrors a failed verified download, which may remove server.jar.
+            jar_path.unlink()
+            return InstallResult(
+                success=False,
+                status=InstallStatus.FAILED,
+                message="download failed",
+            )
+
+    monkeypatch.setattr(upgrade.server_storage, "get_server", lambda _id: server)
+    monkeypatch.setattr(upgrade, "get_server_process_registry", lambda: Registry())
+    monkeypatch.setattr(
+        upgrade.backup_service, "run_adhoc_backup", lambda *_args, **_kwargs: {"id": "snap_1"}
+    )
+    monkeypatch.setattr(upgrade, "get_installer_for", lambda *_args: FailingInstaller())
+
+    with pytest.raises(upgrade.UpgradeError, match="download failed"):
+        upgrade.upgrade_server("srv_upgrade", "1.21")
+
+    assert jar_path.read_bytes() == b"known-good-old-server"
+
+
+@pytest.mark.parametrize(
+    ("loader", "target", "message"),
+    [
+        ("fabric", "1.21", "only supports vanilla and Paper"),
+        ("vanilla", "1.20.1", "must be newer"),
+        ("paper", "1.20", "must be newer"),
+    ],
+)
+def test_upgrade_rejects_unsupported_loaders_and_downgrades(monkeypatch, loader, target, message):
+    from backend.server import upgrade
+
+    monkeypatch.setattr(upgrade.server_storage, "get_server", lambda _id: _server(loader=loader))
+
+    with pytest.raises(upgrade.UpgradeError, match=message):
+        upgrade.upgrade_server("srv_upgrade", target)
+
+
+def test_upgrade_route_starts_a_tracked_upgrade_job(client, tmp_servers_root, monkeypatch):
+    import threading
+    import time
+
+    from backend.server import storage
+    from backend.server import upgrade as upgrade_service
+
+    server = storage.create_server({
+        "name": "Upgrade me",
+        "version": "1.20.1",
+        "loader": "vanilla",
+        "port": 25565,
+        "installPath": "upgrade-me",
+    })
+    called = []
+    complete = threading.Event()
+
+    def fake_upgrade(server_id, target_version, *, progress_callback):
+        called.append((server_id, target_version))
+        progress_callback("downloading_server_jar", {"bytes_done": 3, "bytes_total": 10})
+        complete.set()
+        return {"snapshot_id": "snap_upgrade"}
+
+    monkeypatch.setattr(upgrade_service, "upgrade_server", fake_upgrade)
+
+    response = client.post(f"/api/servers/{server['id']}/upgrade", json={"version": "1.21"})
+
+    assert response.status_code == 202
+    assert complete.wait(timeout=2)
+    # The worker updates shared install-progress so the existing polling UI can
+    # represent a long-running upgrade without a second job protocol.
+    for _ in range(20):
+        progress = client.get(f"/api/servers/{server['id']}/install/progress").get_json()
+        if progress.get("phase") == "done":
+            break
+        time.sleep(0.01)
+    assert called == [(server["id"], "1.21")]
+    assert progress["phase"] == "done"
+    assert progress["kind"] == "upgrade"
+    assert progress["snapshot_id"] == "snap_upgrade"

--- a/tests/test_url_map_bucket_coverage.py
+++ b/tests/test_url_map_bucket_coverage.py
@@ -52,8 +52,8 @@ def test_read_and_manage_counts():
     counts = Counter(BUCKETS.values())
     assert counts["read"] == 32
     assert counts["manage"] == 7
-    assert counts["never"] == 58
-    assert sum(counts.values()) == 97
+    assert counts["never"] == 59
+    assert sum(counts.values()) == 98
 
 
 def test_the_console_and_settings_routes_are_never():


### PR DESCRIPTION
## Summary
- Adds an asynchronous, in-place upgrade flow for Vanilla and Paper servers.
- Requires a full server snapshot before stopping the server or replacing `server.jar`.
- Blocks downgrades, same-version upgrades, unstable release identifiers, and modded loaders.
- Preserves and restores the prior `server.jar` if installation or persistence fails; completed upgrades remain stopped for Minecraft's first world-migration boot.
- Adds Settings UI confirmation, progress polling, and failure/snapshot feedback.
- Keeps the upgrade API deliberately unavailable to MCP tokens pending a dedicated rollback contract.

## Verification
- `uv run pytest -q` — 1275 passed
- `npm run build` — passed

The pre-existing root `uv.lock` is untracked and intentionally excluded.