### PR TITLE
feat(mcp): add server operations tools

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -62,16 +62,17 @@ The token's scope decides this, and the **panel** enforces it — not this packa
 
 | Scope | What it reaches |
 |---|---|
-| `read` | List servers and their status · read console output and crash logs · list installed mods and identify them against Modrinth by file hash · CPU and memory use · Java version checks · install progress and failure reasons · search Modrinth and check whether a mod has a build for your Minecraft version and loader |
-| `manage` | Everything above, plus: start / stop / restart a server · install or update one mod by Modrinth project id · delete installed mod jars |
+| `read` | List servers and their status · read console output and crash logs · list installed mods and identify them against Modrinth by file hash · CPU and memory use · Java version checks · loader and Minecraft-version discovery · install progress and failure reasons · backup coverage and snapshot metadata · search Modrinth and check whether a mod has a build for your Minecraft version and loader |
+| `manage` | Everything above, plus: start / stop / restart a server · start or retry server installation using its saved configuration · install or update one mod by Modrinth project id · delete installed mod jars |
 
 **`read` is the documented default.** It answers every diagnostic question and cannot change
 anything on your server.
 
 Whatever the scope, a large part of the panel is refused to **every** token: the console, file
 reading and writing, server settings, creating or deleting servers, Java installation, the
-updater, backups and snapshot restore, world import, and all player administration including the
-player lists. Those refusals happen in the panel, and this package surfaces them as they are
+updater, backup creation and snapshot restore, world import, and all player administration
+including the player lists. The read-only backup and snapshot metadata tools do not expose archive
+paths or files. Those refusals happen in the panel, and this package surfaces them as they are
 rather than hiding the tools.
 
 ### Known limitation: mods in subfolders

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fabricator-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for the Fabricator Minecraft panel"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp/src/fabricator_mcp/__init__.py
+++ b/mcp/src/fabricator_mcp/__init__.py
@@ -8,4 +8,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/mcp/src/fabricator_mcp/projection.py
+++ b/mcp/src/fabricator_mcp/projection.py
@@ -65,6 +65,39 @@ def project_server(record: Any) -> dict[str, Any]:
     })
 
 
+def project_snapshot(record: Any) -> dict[str, Any]:
+    """The recovery metadata an assistant can safely reason about.
+
+    Host paths are not useful to a diagnostic conversation and must stay out of
+    its context even though the panel already redacts them for token callers.
+    """
+    if not isinstance(record, dict):
+        return {}
+    return drop_empty({
+        "id": record.get("id"),
+        "type": record.get("type"),
+        "createdAt": record.get("createdAt"),
+        "fileName": record.get("fileName"),
+        "sizeBytes": record.get("sizeBytes"),
+        "status": record.get("status"),
+    })
+
+
+def project_version_metadata(record: Any) -> dict[str, Any]:
+    """Normalise installer-specific version-list records for MCP context."""
+    if isinstance(record, str):
+        return {"version": record}
+    if not isinstance(record, dict):
+        return {}
+    nested = record.get("loader")
+    nested = nested if isinstance(nested, dict) else {}
+    return drop_empty({
+        "version": record.get("version") or nested.get("version"),
+        "stable": record.get("stable") if "stable" in record else nested.get("stable"),
+        "type": record.get("type") or nested.get("type"),
+    })
+
+
 def project_log_lines(payload: Any, limit: int) -> dict[str, Any]:
     """Flatten stdout/stderr into one ordered list, clamped both ways."""
     if not isinstance(payload, dict):

--- a/mcp/src/fabricator_mcp/routes.py
+++ b/mcp/src/fabricator_mcp/routes.py
@@ -41,6 +41,18 @@ TOOL_ROUTES: dict[str, tuple[tuple[str, str], ...]] = {
         ("GET", "/api/java/status"),
         ("GET", "/api/java/installed"),
     ),
+    "list_loader_game_versions": (
+        ("GET", "/api/loaders/<loader>/versions/game"),
+    ),
+    "list_loader_versions": (
+        ("GET", "/api/loaders/<loader>/versions/loader"),
+    ),
+    "get_backup_status": (
+        ("GET", "/api/servers/<server_id>/backup-summary"),
+    ),
+    "list_snapshots": (
+        ("GET", "/api/servers/<server_id>/snapshots"),
+    ),
     "get_install_progress": (
         ("GET", "/api/servers/<server_id>/install/progress"),
     ),
@@ -64,6 +76,9 @@ TOOL_ROUTES: dict[str, tuple[tuple[str, str], ...]] = {
         ("POST", "/api/servers/<server_id>/stop"),
         ("POST", "/api/servers/<server_id>/restart"),
     ),
+    "install_server": (
+        ("POST", "/api/servers/<server_id>/install"),
+    ),
     "update_or_install_mod": (
         ("POST", "/api/modrinth/mod/<mod_id>/install"),
     ),
@@ -81,12 +96,17 @@ TOOL_SCOPES: dict[str, str] = {
     "list_installed_mods": READ,
     "check_resource_usage": READ,
     "check_java": READ,
+    "list_loader_game_versions": READ,
+    "list_loader_versions": READ,
+    "get_backup_status": READ,
+    "list_snapshots": READ,
     "get_install_progress": READ,
     "check_panel": READ,
     "search_modrinth": READ,
     "get_mod_info": READ,
     "check_mod_compatibility": READ,
     "control_server": MANAGE,
+    "install_server": MANAGE,
     "update_or_install_mod": MANAGE,
     "remove_mods": MANAGE,
 }

--- a/mcp/src/fabricator_mcp/server.py
+++ b/mcp/src/fabricator_mcp/server.py
@@ -78,6 +78,28 @@ def register_read_tools(server, client: PanelClient) -> None:
         return await read_tools.check_java(client, mc_version)
 
     @server.tool()
+    async def list_loader_game_versions(loader: str) -> dict[str, Any]:
+        """List Minecraft versions Fabricator can install for a loader."""
+        return await read_tools.list_loader_game_versions(client, loader)
+
+    @server.tool()
+    async def list_loader_versions(
+        loader: str, mc_version: str | None = None
+    ) -> dict[str, Any]:
+        """List loader builds, optionally for one Minecraft version."""
+        return await read_tools.list_loader_versions(client, loader, mc_version)
+
+    @server.tool()
+    async def get_backup_status(server_id: str) -> dict[str, Any]:
+        """Show backup coverage, latest snapshot, and the next scheduled backup."""
+        return await read_tools.get_backup_status(client, server_id)
+
+    @server.tool()
+    async def list_snapshots(server_id: str) -> dict[str, Any]:
+        """List recovery snapshots. Restoring one remains a deliberate panel-UI action."""
+        return await read_tools.list_snapshots(client, server_id)
+
+    @server.tool()
     async def get_install_progress(server_id: str) -> dict[str, Any]:
         """Show the state of the server's most recent install, including why it failed."""
         return await read_tools.get_install_progress(client, server_id)
@@ -130,6 +152,15 @@ def register_manage_tools(server, client: PanelClient) -> None:
         stop or a restart.
         """
         return await manage_tools.control_server(client, server_id, action)
+
+    @server.tool()
+    async def install_server(server_id: str) -> dict[str, Any]:
+        """Install or retry installation using the server's stored configuration.
+
+        This changes server files and may take several minutes. Poll
+        get_install_progress afterwards; the panel enforces the manage scope.
+        """
+        return await manage_tools.install_server(client, server_id)
 
     @server.tool()
     async def update_or_install_mod(

--- a/mcp/src/fabricator_mcp/tools/manage.py
+++ b/mcp/src/fabricator_mcp/tools/manage.py
@@ -76,6 +76,23 @@ async def control_server(client: PanelClient, server_id: str, action: str) -> di
     })
 
 
+async def install_server(client: PanelClient, server_id: str) -> dict[str, Any]:
+    """Queue installation using the server's already persisted configuration."""
+    server_id = _require_server_id(server_id)
+    # No body: the panel installs the server's stored loader/version/settings.
+    # In particular, this tool must not expose caller-controlled install paths
+    # or modpack archives.
+    payload = await client.post(f"/api/servers/{server_id}/install")
+    payload = payload if isinstance(payload, dict) else {}
+    return drop_empty({
+        "active": payload.get("active"),
+        "phase": payload.get("phase"),
+        "serverId": payload.get("server_id"),
+        "loader": payload.get("loader"),
+        "minecraftVersion": payload.get("mc_version"),
+    })
+
+
 async def update_or_install_mod(
     client: PanelClient,
     server_id: str,

--- a/mcp/src/fabricator_mcp/tools/read.py
+++ b/mcp/src/fabricator_mcp/tools/read.py
@@ -17,11 +17,14 @@ from fabricator_mcp.projection import (
     project_log_lines,
     project_mod_entry,
     project_server,
+    project_snapshot,
+    project_version_metadata,
 )
 
 DEFAULT_LOG_LIMIT = 200
 DEFAULT_SEARCH_LIMIT = 10
 DEFAULT_VERSION_LIMIT = 20
+MAX_METADATA_VERSIONS = 100
 
 #: Said once, on every mods listing, because it is the one thing the listing
 #: cannot show you.
@@ -132,6 +135,69 @@ async def check_java(client: PanelClient, mc_version: str | None = None) -> dict
             entry.get("major") for entry in managed if isinstance(entry, dict)
         ],
     })
+
+
+async def list_loader_game_versions(client: PanelClient, loader: str) -> dict[str, Any]:
+    """List stable Minecraft versions a Fabricator loader can install."""
+    loader = _require(loader, "loader").lower()
+    payload = await client.get(f"/api/loaders/{loader}/versions/game")
+    versions = payload if isinstance(payload, list) else []
+    return {
+        "loader": loader,
+        "minecraftVersions": [
+            projected for version in versions[:MAX_METADATA_VERSIONS]
+            if (projected := project_version_metadata(version))
+        ],
+    }
+
+
+async def list_loader_versions(
+    client: PanelClient, loader: str, mc_version: str | None = None
+) -> dict[str, Any]:
+    """List loader builds, optionally narrowed to one Minecraft version."""
+    loader = _require(loader, "loader").lower()
+    version = mc_version.strip() if isinstance(mc_version, str) and mc_version.strip() else None
+    payload = await client.get(
+        f"/api/loaders/{loader}/versions/loader",
+        params={"mc_version": version},
+    )
+    versions = payload if isinstance(payload, list) else []
+    return drop_empty({
+        "loader": loader,
+        "minecraftVersion": version,
+        "versions": [
+            projected for item in versions[:MAX_METADATA_VERSIONS]
+            if (projected := project_version_metadata(item))
+        ],
+    })
+
+
+async def get_backup_status(client: PanelClient, server_id: str) -> dict[str, Any]:
+    """Show whether this server has usable backups and when one is next scheduled."""
+    server_id = _require(server_id, "server_id")
+    payload = await client.get(f"/api/servers/{server_id}/backup-summary")
+    payload = payload if isinstance(payload, dict) else {}
+    next_run = payload.get("next_run")
+    next_run = next_run if isinstance(next_run, dict) else {}
+    return drop_empty({
+        "totalSnapshots": payload.get("total_snapshots"),
+        "totalSizeBytes": payload.get("total_size_bytes"),
+        "lastSnapshot": project_snapshot(payload.get("last_snapshot")),
+        "nextRun": drop_empty({
+            "configId": next_run.get("config_id"),
+            "configName": next_run.get("config_name"),
+            "nextRunTime": next_run.get("next_run_time"),
+        }),
+        "configsCount": payload.get("configs_count"),
+    })
+
+
+async def list_snapshots(client: PanelClient, server_id: str) -> dict[str, Any]:
+    """List backup snapshots for recovery inspection; restore remains panel-UI only."""
+    server_id = _require(server_id, "server_id")
+    payload = await client.get(f"/api/servers/{server_id}/snapshots")
+    snapshots = payload if isinstance(payload, list) else []
+    return {"snapshots": [project_snapshot(snapshot) for snapshot in snapshots if isinstance(snapshot, dict)]}
 
 
 async def get_install_progress(client: PanelClient, server_id: str) -> dict[str, Any]:

--- a/mcp/tests/test_manage_tools_wire.py
+++ b/mcp/tests/test_manage_tools_wire.py
@@ -69,6 +69,21 @@ async def test_control_server_response_is_projected():
     assert set(result["server"]) == {"id", "status"}
 
 
+async def test_install_server_starts_the_panel_install_worker_without_a_body():
+    panel = Panel({"active": True, "phase": "starting", "server_id": "s1", "loader": "paper", "mc_version": "1.21.4"})
+    async with client_for(panel) as client:
+        result = await manage_tools.install_server(client, "s1")
+    assert panel.calls == [("POST", "/api/servers/s1/install")]
+    assert panel.body() is None
+    assert result == {
+        "active": True,
+        "phase": "starting",
+        "serverId": "s1",
+        "loader": "paper",
+        "minecraftVersion": "1.21.4",
+    }
+
+
 async def test_update_or_install_mod_sends_the_required_body():
     panel = Panel({"success": True, "message": "Mod installed successfully", "file": "sodium.jar"})
     async with client_for(panel) as client:

--- a/mcp/tests/test_tool_routes.py
+++ b/mcp/tests/test_tool_routes.py
@@ -72,4 +72,4 @@ def test_the_tool_set_is_narrower_than_the_ceiling():
     """Curation, stated as a fact: tools use a strict subset of the permitted routes."""
     used = {route for routes in TOOL_ROUTES.values() for route in routes}
     assert used < PANEL_TOKEN_REACHABLE
-    assert len(TOOL_ROUTES) == 14
+    assert len(TOOL_ROUTES) == 19

--- a/mcp/tests/test_tool_surface.py
+++ b/mcp/tests/test_tool_surface.py
@@ -47,7 +47,7 @@ async def test_advertised_tools_are_exactly_the_route_table():
     server = build_server(_CONFIG, client=_client(lambda r: httpx.Response(200, json={})))
     advertised = {tool.name for tool in await server.list_tools()}
     assert advertised == set(TOOL_ROUTES)
-    assert len(advertised) == 14
+    assert len(advertised) == 19
 
 
 async def test_manage_tools_are_advertised_even_though_a_read_token_cannot_use_them():

--- a/mcp/tests/test_tools_wire.py
+++ b/mcp/tests/test_tools_wire.py
@@ -135,6 +135,69 @@ async def test_check_java_without_a_version_sends_no_params():
     assert panel.query() == {}
 
 
+async def test_list_loader_game_versions_uses_the_loader_metadata_route():
+    panel = Panel({"/api/loaders/paper/versions/game": [
+        {"version": "1.21.4", "stable": True, "type": "release", "noise": "drop"},
+    ]})
+    async with client_for(panel) as client:
+        result = await read_tools.list_loader_game_versions(client, "paper")
+    assert panel.calls == [("GET", "/api/loaders/paper/versions/game")]
+    assert result == {"loader": "paper", "minecraftVersions": [
+        {"version": "1.21.4", "stable": True, "type": "release"},
+    ]}
+
+
+async def test_list_loader_versions_sends_an_optional_minecraft_version():
+    panel = Panel({"/api/loaders/paper/versions/loader": [
+        {"loader": {"version": "0.16.0", "stable": True}, "noise": "drop"},
+    ]})
+    async with client_for(panel) as client:
+        result = await read_tools.list_loader_versions(client, "paper", "1.21.4")
+    assert panel.calls == [("GET", "/api/loaders/paper/versions/loader")]
+    assert panel.query() == {"mc_version": "1.21.4"}
+    assert result == {"loader": "paper", "minecraftVersion": "1.21.4", "versions": [
+        {"version": "0.16.0", "stable": True},
+    ]}
+
+
+async def test_get_backup_status_projects_summary_without_its_storage_path():
+    panel = Panel({"/api/servers/s1/backup-summary": {
+        "total_snapshots": 3,
+        "total_size_bytes": 1234,
+        "last_snapshot": {"id": "snap-1", "fileName": "safe.tar", "filePath": "/srv/secrets"},
+        "next_run": {"config_id": "nightly", "config_name": "Nightly", "next_run_time": "2026-08-20T01:00:00Z"},
+        "configs_count": 1,
+        "defaultStoragePath": "/srv/fabricator/backups",
+    }})
+    async with client_for(panel) as client:
+        result = await read_tools.get_backup_status(client, "s1")
+    assert panel.calls == [("GET", "/api/servers/s1/backup-summary")]
+    assert result == {
+        "totalSnapshots": 3,
+        "totalSizeBytes": 1234,
+        "lastSnapshot": {"id": "snap-1", "fileName": "safe.tar"},
+        "nextRun": {"configId": "nightly", "configName": "Nightly", "nextRunTime": "2026-08-20T01:00:00Z"},
+        "configsCount": 1,
+    }
+    assert "srv" not in str(result)
+
+
+async def test_list_snapshots_projects_recovery_metadata_without_file_paths():
+    panel = Panel({"/api/servers/s1/snapshots": [{
+        "id": "snap-1", "type": "backup", "createdAt": "2026-08-19T00:00:00Z",
+        "fileName": "before-upgrade.tar", "filePath": "/srv/fabricator/backups/before-upgrade.tar",
+        "sizeBytes": 1234, "status": "success",
+    }]})
+    async with client_for(panel) as client:
+        result = await read_tools.list_snapshots(client, "s1")
+    assert panel.calls == [("GET", "/api/servers/s1/snapshots")]
+    assert result == {"snapshots": [{
+        "id": "snap-1", "type": "backup", "createdAt": "2026-08-19T00:00:00Z",
+        "fileName": "before-upgrade.tar", "sizeBytes": 1234, "status": "success",
+    }]}
+    assert "srv" not in str(result)
+
+
 async def test_get_install_progress_route_and_error_field():
     panel = Panel({"/api/servers/s1/install/progress": {"active": False, "phase": "failed", "error": "boom"}})
     async with client_for(panel) as client:

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "fabricator-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds read-only MCP tools for loader/Minecraft-version discovery, backup coverage, and recovery-snapshot metadata.
- Adds a manage-scoped `install_server` tool that starts or retries an install using only the server's saved configuration; it sends no caller-controlled body.
- Keeps archive paths, backup creation, restore, and file access out of the MCP surface.
- Updates the package to v0.2.0 and documents the expanded scope.

## Verification
- `cd mcp && uv run pytest -q` — 160 passed
- `uv run pytest -q` — 1275 passed
- `cd mcp && uv build` — wheel and sdist built successfully

The pre-existing root `uv.lock` remains untracked and is excluded.